### PR TITLE
Refactor/init modules

### DIFF
--- a/burn-core/src/module/state.rs
+++ b/burn-core/src/module/state.rs
@@ -338,7 +338,7 @@ mod tests {
     }
 
     pub fn create_model() -> nn::Linear<TestBackend> {
-        nn::Linear::<crate::TestBackend>::new(&nn::LinearConfig::new(32, 32).with_bias(true))
+        nn::LinearConfig::new(32, 32).with_bias(true).init()
     }
 }
 

--- a/burn-core/src/nn/attention/mha.rs
+++ b/burn-core/src/nn/attention/mha.rs
@@ -60,6 +60,27 @@ pub struct MhaInput<B: Backend> {
     mask_attn: Option<Tensor<B, 3, Bool>>,
 }
 
+impl MultiHeadAttentionConfig {
+    /// Initialize a new [multihead attention](MultiHeadAttention) module.
+    pub fn init<B: Backend>(&self) -> MultiHeadAttention<B> {
+        let linear = |config: &Self| {
+            Param::from(nn::LinearConfig::new(config.d_model, config.d_model).init())
+        };
+
+        MultiHeadAttention {
+            query: linear(self),
+            key: linear(self),
+            value: linear(self),
+            output: linear(self),
+            dropout: nn::DropoutConfig::new(self.dropout).init(),
+            activation: nn::GELU::new(),
+            n_heads: self.n_heads,
+            d_k: self.d_model / self.n_heads,
+            min_float: self.min_float,
+        }
+    }
+}
+
 impl<B: Backend> MhaInput<B> {
     /// Create a [multihead attention](MultiHeadAttention) input argument
     /// by setting the query, key and value to the given tensor.
@@ -107,25 +128,6 @@ pub struct MhaOutput<B: Backend> {
 }
 
 impl<B: Backend> MultiHeadAttention<B> {
-    /// Create the module from the given configuration.
-    pub fn new(config: &MultiHeadAttentionConfig) -> Self {
-        let linear = |config: &MultiHeadAttentionConfig| {
-            Param::from(nn::LinearConfig::new(config.d_model, config.d_model).init())
-        };
-
-        Self {
-            query: linear(config),
-            key: linear(config),
-            value: linear(config),
-            output: linear(config),
-            dropout: nn::DropoutConfig::new(config.dropout).init(),
-            activation: nn::GELU::new(),
-            n_heads: config.n_heads,
-            d_k: config.d_model / config.n_heads,
-            min_float: config.min_float,
-        }
-    }
-
     /// Applies the forward pass on the input tensors.
     ///
     /// # Shapes
@@ -263,9 +265,7 @@ mod tests {
     #[test]
     fn test_self_attention_shapes() {
         let [batch_size, seq_length, d_model, n_heads] = [7, 13, 32, 4];
-        let mha = MultiHeadAttention::<TestBackend>::new(&MultiHeadAttentionConfig::new(
-            d_model, n_heads,
-        ));
+        let mha = MultiHeadAttentionConfig::new(d_model, n_heads).init::<TestBackend>();
         let input = MhaInput::self_attn(Tensor::random(
             [batch_size, seq_length, d_model],
             Distribution::Standard,
@@ -288,9 +288,7 @@ mod tests {
     #[test]
     fn test_generic_mha_shapes() {
         let [batch_size, seq_length_1, seq_length_2, d_model, n_heads] = [7, 13, 15, 32, 4];
-        let mha = MultiHeadAttention::<TestBackend>::new(&MultiHeadAttentionConfig::new(
-            d_model, n_heads,
-        ));
+        let mha = MultiHeadAttentionConfig::new(d_model, n_heads).init::<TestBackend>();
         let input = MhaInput::new(
             Tensor::random([batch_size, seq_length_1, d_model], Distribution::Standard),
             Tensor::random([batch_size, seq_length_2, d_model], Distribution::Standard),
@@ -314,7 +312,7 @@ mod tests {
     #[test]
     fn test_self_attention_mask_pad() {
         let [batch_size, seq_length, d_model, n_heads, num_padded] = [3, 6, 32, 2, 2];
-        let mha = MultiHeadAttention::new(&MultiHeadAttentionConfig::new(d_model, n_heads));
+        let mha = MultiHeadAttentionConfig::new(d_model, n_heads).init::<TestBackend>();
 
         // Create a padding mask
         let mask_pad: Tensor<TestBackend, 2, Int> = Tensor::zeros([batch_size, seq_length]);
@@ -361,7 +359,7 @@ mod tests {
     #[test]
     fn test_autoregressive_mask_should_have_same_output_as_autoregressive_decoding() {
         let [batch_size, seq_length, d_model, n_heads] = [3, 4, 12, 2];
-        let mha = MultiHeadAttention::new(&MultiHeadAttentionConfig::new(d_model, n_heads));
+        let mha = MultiHeadAttentionConfig::new(d_model, n_heads).init::<TestBackend>();
 
         let tensor = Tensor::<TestBackend, 3>::random(
             [batch_size, seq_length, d_model],

--- a/burn-core/src/nn/attention/mha.rs
+++ b/burn-core/src/nn/attention/mha.rs
@@ -110,10 +110,7 @@ impl<B: Backend> MultiHeadAttention<B> {
     /// Create the module from the given configuration.
     pub fn new(config: &MultiHeadAttentionConfig) -> Self {
         let linear = |config: &MultiHeadAttentionConfig| {
-            Param::from(nn::Linear::new(&nn::LinearConfig::new(
-                config.d_model,
-                config.d_model,
-            )))
+            Param::from(nn::LinearConfig::new(config.d_model, config.d_model).init())
         };
 
         Self {

--- a/burn-core/src/nn/attention/mha.rs
+++ b/burn-core/src/nn/attention/mha.rs
@@ -118,7 +118,7 @@ impl<B: Backend> MultiHeadAttention<B> {
             key: linear(config),
             value: linear(config),
             output: linear(config),
-            dropout: nn::Dropout::new(&nn::DropoutConfig::new(config.dropout)),
+            dropout: nn::DropoutConfig::new(config.dropout).init(),
             activation: nn::GELU::new(),
             n_heads: config.n_heads,
             d_k: config.d_model / config.n_heads,

--- a/burn-core/src/nn/conv/conv2d.rs
+++ b/burn-core/src/nn/conv/conv2d.rs
@@ -61,40 +61,42 @@ pub struct Conv2d<B: Backend> {
     padding: Conv2dPaddingConfig,
 }
 
-impl<B: Backend> Conv2d<B> {
-    /// Create the module from the given configuration.
-    pub fn new(config: &Conv2dConfig) -> Self {
-        let k = (config.channels[0] * config.kernel_size[0] * config.kernel_size[1]) as f64;
+impl Conv2dConfig {
+    /// Initialize a new [conv2d](Conv2d) module.
+    pub fn init<B: Backend>(&self) -> Conv2d<B> {
+        let k = (self.channels[0] * self.kernel_size[0] * self.kernel_size[1]) as f64;
         let k = sqrt(1.0 / k);
 
-        let initializer = if let Initializer::UniformDefault = config.initializer {
+        let initializer = if let Initializer::UniformDefault = self.initializer {
             Initializer::Uniform(-k, k)
         } else {
-            config.initializer.clone()
+            self.initializer.clone()
         };
 
         let weight = initializer.init([
-            config.channels[1],
-            config.channels[0],
-            config.kernel_size[0],
-            config.kernel_size[1],
+            self.channels[1],
+            self.channels[0],
+            self.kernel_size[0],
+            self.kernel_size[1],
         ]);
 
-        let bias = if config.bias {
-            Some(initializer.init([config.channels[1]]))
+        let bias = if self.bias {
+            Some(initializer.init([self.channels[1]]))
         } else {
             None
         };
 
-        Self {
+        Conv2d {
             weight: Param::from(weight),
             bias: Param::from(bias),
-            stride: [1, 1], // TODO: Add the stride to the configuration when properly supported.
-            kernel_size: config.kernel_size,
-            padding: config.padding.clone(),
+            stride: [1, 1], // TODO: Add the stride to the config when properly supported.
+            kernel_size: self.kernel_size,
+            padding: self.padding.clone(),
         }
     }
+}
 
+impl<B: Backend> Conv2d<B> {
     /// Applies the forward pass on the input tensor.
     ///
     /// # Shapes
@@ -141,32 +143,34 @@ impl Conv2dPaddingConfig {
 
 #[cfg(test)]
 mod tests {
+    use burn_tensor::Data;
+
     use super::*;
-    pub type TB = burn_ndarray::NdArrayBackend<f32>;
+    use crate::TestBackend;
 
     #[test]
     fn initializer_default() {
-        TB::seed(0);
+        TestBackend::seed(0);
+
         let config = Conv2dConfig::new([5, 1], [5, 5]);
         let k = (config.channels[0] * config.kernel_size[0] * config.kernel_size[1]) as f64;
-        let k = sqrt(1.0 / k);
+        let k = sqrt(1.0 / k) as f32;
+        let conv = config.init::<TestBackend>();
+
         assert_eq!(config.initializer, Initializer::UniformDefault);
-        let conv: Conv2d<TB> = Conv2d::new(&config);
-        for item in conv.weight.to_data().value.iter() {
-            if *item < -k as f32 || *item > k as f32 {
-                panic!("Element ({item}) is not within the range of (-{k},{k})");
-            }
-        }
+        conv.weight.to_data().assert_in_range(-k, k);
     }
 
     #[test]
     fn initializer_zeros() {
-        TB::seed(0);
+        TestBackend::seed(0);
+
         let config = Conv2dConfig::new([5, 2], [5, 5]).with_initializer(Initializer::Zeros);
+        let conv = config.init::<TestBackend>();
+
         assert_eq!(config.initializer, Initializer::Zeros);
-        let conv: Conv2d<TB> = Conv2d::new(&config);
-        for item in conv.weight.to_data().value.iter() {
-            assert_eq!(*item, 0.0f32);
-        }
+        conv.weight
+            .to_data()
+            .assert_approx_eq(&Data::zeros(conv.weight.shape()), 3);
     }
 }

--- a/burn-core/src/nn/dropout.rs
+++ b/burn-core/src/nn/dropout.rs
@@ -21,12 +21,14 @@ pub struct Dropout {
     prob: f64,
 }
 
-impl Dropout {
-    /// Create the module from the given configuration.
-    pub fn new(config: &DropoutConfig) -> Self {
-        Self { prob: config.prob }
+impl DropoutConfig {
+    /// Initialize a new [dropout](Dropout) module.
+    pub fn init(&self) -> Dropout {
+        Dropout { prob: self.prob }
     }
+}
 
+impl Dropout {
     /// Applies the forward pass on the input tensor.
     ///
     /// # Shapes
@@ -61,7 +63,7 @@ mod tests {
     #[test]
     fn with_ad_backend_should_mark_input() {
         let tensor = Tensor::<TestADBackend, 2>::ones(Shape::new([100, 100]));
-        let dropout = Dropout::new(&DropoutConfig { prob: 0.5 });
+        let dropout = DropoutConfig::new(0.5).init();
 
         let output = dropout.forward(tensor.clone());
 
@@ -71,7 +73,7 @@ mod tests {
     #[test]
     fn without_ad_backend_should_not_change_input() {
         let tensor = Tensor::<TestBackend, 2>::ones(Shape::new([100, 100]));
-        let dropout = Dropout::new(&DropoutConfig { prob: 0.5 });
+        let dropout = DropoutConfig::new(0.5).init();
 
         let output = dropout.forward(tensor.clone());
 

--- a/burn-core/src/nn/gelu.rs
+++ b/burn-core/src/nn/gelu.rs
@@ -6,7 +6,7 @@ use crate::tensor::Tensor;
 pub struct GELU {}
 
 impl GELU {
-    /// Create the module from the given configuration.
+    /// Create the module.
     pub fn new() -> Self {
         Self {}
     }

--- a/burn-core/src/nn/linear.rs
+++ b/burn-core/src/nn/linear.rs
@@ -43,31 +43,33 @@ pub struct Linear<B: Backend> {
     bias: Param<Option<Tensor<B, 1>>>,
 }
 
-impl<B: Backend> Linear<B> {
-    /// Create the module from the given configuration.
-    pub fn new(config: &LinearConfig) -> Self {
-        let k = sqrt(1.0 / config.d_input as f64);
+impl LinearConfig {
+    /// Initialize a new [linear](Linear) module.
+    pub fn init<B: Backend>(&self) -> Linear<B> {
+        let k = sqrt(1.0 / self.d_input as f64);
 
-        let initializer = if let Initializer::UniformDefault = config.initializer {
+        let initializer = if let Initializer::UniformDefault = self.initializer {
             Initializer::Uniform(-k, k)
         } else {
-            config.initializer.clone()
+            self.initializer.clone()
         };
 
-        let weight = initializer.init([config.d_input, config.d_output]);
+        let weight = initializer.init([self.d_input, self.d_output]);
 
-        let bias = if config.bias {
-            Some(initializer.init([config.d_output]))
+        let bias = if self.bias {
+            Some(initializer.init([self.d_output]))
         } else {
             None
         };
 
-        Self {
+        Linear {
             weight: Param::from(weight),
             bias: Param::from(bias),
         }
     }
+}
 
+impl<B: Backend> Linear<B> {
     /// Applies the forward pass on the input tensor.
     ///
     /// # Shapes
@@ -87,31 +89,30 @@ impl<B: Backend> Linear<B> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    pub type TB = burn_ndarray::NdArrayBackend<f32>;
+    use crate::TestBackend;
+    use burn_tensor::Data;
 
     #[test]
     fn initializer_default() {
-        TB::seed(0);
+        TestBackend::seed(0);
         let config = LinearConfig::new(5, 5);
-        let k = sqrt(1.0 / config.d_input as f64);
+        let k = sqrt(1.0 / config.d_input as f64) as f32;
+        let linear = config.init::<TestBackend>();
 
         assert_eq!(config.initializer, Initializer::UniformDefault);
-        let conv: Linear<TB> = Linear::new(&config);
-        for item in conv.weight.to_data().value.iter() {
-            if *item < -k as f32 || *item > k as f32 {
-                panic!("Element ({item}) is not within the range of (-{k},{k})");
-            }
-        }
+        linear.weight.to_data().assert_in_range(-k, k);
     }
 
     #[test]
     fn initializer_zeros() {
-        TB::seed(0);
+        TestBackend::seed(0);
         let config = LinearConfig::new(5, 5).with_initializer(Initializer::Zeros);
+        let linear = config.init::<TestBackend>();
+
         assert_eq!(config.initializer, Initializer::Zeros);
-        let conv: Linear<TB> = Linear::new(&config);
-        for item in conv.weight.to_data().value.iter() {
-            assert_eq!(*item, 0.0f32);
-        }
+        linear
+            .weight
+            .to_data()
+            .assert_approx_eq(&Data::zeros(linear.weight.shape()), 3);
     }
 }

--- a/burn-core/src/nn/linear.rs
+++ b/burn-core/src/nn/linear.rs
@@ -95,6 +95,7 @@ mod tests {
     #[test]
     fn initializer_default() {
         TestBackend::seed(0);
+
         let config = LinearConfig::new(5, 5);
         let k = sqrt(1.0 / config.d_input as f64) as f32;
         let linear = config.init::<TestBackend>();
@@ -106,6 +107,7 @@ mod tests {
     #[test]
     fn initializer_zeros() {
         TestBackend::seed(0);
+
         let config = LinearConfig::new(5, 5).with_initializer(Initializer::Zeros);
         let linear = config.init::<TestBackend>();
 

--- a/burn-core/src/nn/norm/batch.rs
+++ b/burn-core/src/nn/norm/batch.rs
@@ -34,25 +34,27 @@ pub struct BatchNorm<B: Backend, const D: usize> {
     epsilon: f64,
 }
 
-impl<const D: usize, B: Backend> BatchNorm<B, D> {
-    /// Create the module from the given configuration.
-    pub fn new(config: &BatchNormConfig) -> Self {
-        let gamma = Tensor::ones([config.num_features]);
-        let beta = Tensor::zeros([config.num_features]);
+impl BatchNormConfig {
+    /// Initialize a new [batch norm](BatchNorm) module.
+    pub fn init<B: Backend, const D: usize>(&self) -> BatchNorm<B, D> {
+        let gamma = Tensor::ones([self.num_features]);
+        let beta = Tensor::zeros([self.num_features]);
 
-        let running_mean = Tensor::zeros([config.num_features]);
-        let running_var = Tensor::ones([config.num_features]);
+        let running_mean = Tensor::zeros([self.num_features]);
+        let running_var = Tensor::ones([self.num_features]);
 
-        Self {
+        BatchNorm {
             gamma: Param::from(gamma),
             beta: Param::from(beta),
             running_mean: Param::from(RunningState::new(running_mean)),
             running_var: Param::from(RunningState::new(running_var)),
-            momentum: config.momentum,
-            epsilon: config.epsilon,
+            momentum: self.momentum,
+            epsilon: self.epsilon,
         }
     }
+}
 
+impl<const D: usize, B: Backend> BatchNorm<B, D> {
     /// Applies the forward pass on the input tensor.
     ///
     /// # Shapes
@@ -164,8 +166,7 @@ mod tests_1d {
 
     #[test]
     fn batch_norm_forward_train() {
-        let config = BatchNormConfig::new(3);
-        let module = BatchNorm::<TestADBackend, 1>::new(&config);
+        let module = BatchNormConfig::new(3).init::<TestADBackend, 1>();
 
         let output = module.forward(input_tensor());
 
@@ -188,8 +189,7 @@ mod tests_1d {
 
     #[test]
     fn batch_norm_forward_inference() {
-        let config = BatchNormConfig::new(3);
-        let module = BatchNorm::<TestADBackend, 1>::new(&config);
+        let module = BatchNormConfig::new(3).init::<TestADBackend, 1>();
 
         module.forward(input_tensor());
         let module = module.inner();
@@ -221,8 +221,7 @@ mod tests_2d {
 
     #[test]
     fn batch_norm_forward_train() {
-        let config = BatchNormConfig::new(3);
-        let module = BatchNorm::<TestADBackend, 2>::new(&config);
+        let module = BatchNormConfig::new(3).init::<TestADBackend, 2>();
 
         let output = module.forward(input_tensor());
 
@@ -245,8 +244,7 @@ mod tests_2d {
 
     #[test]
     fn batch_norm_forward_inference() {
-        let config = BatchNormConfig::new(3);
-        let module = BatchNorm::<TestADBackend, 2>::new(&config);
+        let module = BatchNormConfig::new(3).init::<TestADBackend, 2>();
 
         module.forward(input_tensor());
         let module = module.inner();
@@ -271,8 +269,7 @@ mod tests_2d {
 
     #[test]
     fn batch_norm_running_mean() {
-        let config = BatchNormConfig::new(3);
-        let module = BatchNorm::<TestADBackend, 2>::new(&config);
+        let module = BatchNormConfig::new(3).init::<TestADBackend, 2>();
 
         let _output = module.forward(input_tensor());
 
@@ -286,8 +283,7 @@ mod tests_2d {
 
     #[test]
     fn batch_norm_running_var() {
-        let config = BatchNormConfig::new(3);
-        let module = BatchNorm::<TestADBackend, 2>::new(&config);
+        let module = BatchNormConfig::new(3).init::<TestADBackend, 2>();
 
         let _output = module.forward(input_tensor());
 
@@ -301,8 +297,7 @@ mod tests_2d {
 
     #[test]
     fn batch_norm_running_mean_inner_module() {
-        let config = BatchNormConfig::new(3);
-        let module = BatchNorm::<TestADBackend, 2>::new(&config);
+        let module = BatchNormConfig::new(3).init::<TestADBackend, 2>();
 
         let _output = module.forward(input_tensor());
 
@@ -319,8 +314,7 @@ mod tests_2d {
 
     #[test]
     fn batch_norm_grads() {
-        let config = BatchNormConfig::new(3);
-        let module = BatchNorm::<TestADBackend, 2>::new(&config);
+        let module = BatchNormConfig::new(3).init::<TestADBackend, 2>();
         let input = input_tensor().require_grad();
 
         let output = module.forward(input.clone());

--- a/burn-core/src/nn/norm/layer.rs
+++ b/burn-core/src/nn/norm/layer.rs
@@ -28,19 +28,21 @@ pub struct LayerNorm<B: Backend> {
     epsilon: f64,
 }
 
-impl<B: Backend> LayerNorm<B> {
-    /// Create the module from the given configuration.
-    pub fn new(config: &LayerNormConfig) -> Self {
-        let gamma = Tensor::ones([config.d_model]);
-        let beta = Tensor::zeros([config.d_model]);
+impl LayerNormConfig {
+    /// Initialize a new [layer norm](LayerNorm) module.
+    pub fn init<B: Backend>(&self) -> LayerNorm<B> {
+        let gamma = Tensor::ones([self.d_model]);
+        let beta = Tensor::zeros([self.d_model]);
 
-        Self {
+        LayerNorm {
             gamma: Param::from(gamma),
             beta: Param::from(beta),
-            epsilon: config.epsilon,
+            epsilon: self.epsilon,
         }
     }
+}
 
+impl<B: Backend> LayerNorm<B> {
     /// Applies the forward pass on the input tensor.
     ///
     /// # Shapes
@@ -71,8 +73,7 @@ mod tests {
 
     #[test]
     fn layer_norm_forward() {
-        let config = LayerNormConfig::new(10);
-        let module = LayerNorm::<TestBackend>::new(&config);
+        let module = LayerNormConfig::new(10).init::<TestBackend>();
         let input = Tensor::from_data(Data::from([[
             -0.6897, -2.7106, 2.2222, -1.0330, -0.8933, 1.1765, 0.0601, 1.5252, -0.3630, 0.6728,
         ]]));
@@ -90,8 +91,7 @@ mod tests {
     #[cfg(feature = "std")]
     #[test]
     fn layer_norm_backward() {
-        let config = LayerNormConfig::new(2);
-        let module = LayerNorm::<TestADBackend>::new(&config);
+        let module = LayerNormConfig::new(2).init::<TestADBackend>();
         let tensor_1 = Tensor::<TestADBackend, 2>::from_data(Data::from([[0.0, 1.0], [3.0, 4.0]]))
             .require_grad();
         let tensor_2 = Tensor::<TestADBackend, 2>::from_data(Data::from([[6.0, 7.0], [9.0, 10.0]]))

--- a/burn-core/src/nn/pool/max_pool2d.rs
+++ b/burn-core/src/nn/pool/max_pool2d.rs
@@ -32,16 +32,18 @@ pub struct MaxPool2d {
     padding: MaxPool2dPaddingConfig,
 }
 
-impl MaxPool2d {
-    /// Create the module from the given configuration.
-    pub fn new(config: &MaxPool2dConfig) -> Self {
-        Self {
-            stride: config.strides,
-            kernel_size: config.kernel_size,
-            padding: config.padding.clone(),
+impl MaxPool2dConfig {
+    /// Initialize a new [max pool 2d](MaxPool2d) module.
+    pub fn init(&self) -> MaxPool2d {
+        MaxPool2d {
+            stride: self.strides,
+            kernel_size: self.kernel_size,
+            padding: self.padding.clone(),
         }
     }
+}
 
+impl MaxPool2d {
     /// Applies the forward pass on the input tensor.
     ///
     /// # Shapes

--- a/burn-core/src/nn/relu.rs
+++ b/burn-core/src/nn/relu.rs
@@ -8,7 +8,7 @@ use crate::tensor::Tensor;
 pub struct ReLU {}
 
 impl ReLU {
-    /// Create the module from the given configuration.
+    /// Create the module.
     pub fn new() -> Self {
         Self {}
     }

--- a/burn-core/src/nn/transformer/encoder.rs
+++ b/burn-core/src/nn/transformer/encoder.rs
@@ -76,19 +76,20 @@ impl<B: Backend> TransformerEncoderInput<B> {
         self
     }
 }
-
-impl<B: Backend> TransformerEncoder<B> {
-    /// Create the module from the given configuration.
-    pub fn new(config: &TransformerEncoderConfig) -> Self {
-        let layers = (0..config.n_layers)
-            .map(|_| TransformerEncoderLayer::new(config))
+impl TransformerEncoderConfig {
+    /// Initialize a new [transformer encoder](TransformerEncoder) module.
+    pub fn init<B: Backend>(&self) -> TransformerEncoder<B> {
+        let layers = (0..self.n_layers)
+            .map(|_| TransformerEncoderLayer::new(self))
             .collect::<Vec<_>>();
 
-        Self {
+        TransformerEncoder {
             layers: Param::from(layers),
         }
     }
+}
 
+impl<B: Backend> TransformerEncoder<B> {
     /// Applies the forward pass on the input tensor.
     ///
     /// # Shapes
@@ -150,17 +151,16 @@ struct TransformerEncoderLayer<B: Backend> {
 
 impl<B: Backend> TransformerEncoderLayer<B> {
     fn new(config: &TransformerEncoderConfig) -> Self {
-        let config_norm = LayerNormConfig::new(config.d_model);
         let config_mha = MultiHeadAttentionConfig::new(config.d_model, config.n_heads)
-            .with_dropout(config.dropout);
-        let config_pwff = PositionWiseFeedForwardConfig::new(config.d_model, config.d_ff)
             .with_dropout(config.dropout);
 
         let mha = MultiHeadAttention::new(&config_mha);
-        let norm_1 = LayerNorm::new(&config_norm);
-        let norm_2 = LayerNorm::new(&config_norm);
+        let norm_1 = LayerNormConfig::new(config.d_model).init();
+        let norm_2 = LayerNormConfig::new(config.d_model).init();
         let dropout = DropoutConfig::new(config.dropout).init();
-        let pwff = PositionWiseFeedForward::new(&config_pwff);
+        let pwff = PositionWiseFeedForwardConfig::new(config.d_model, config.d_ff)
+            .with_dropout(config.dropout)
+            .init();
 
         Self {
             mha: Param::from(mha),
@@ -308,7 +308,7 @@ mod tests {
 
     fn test_autoregressive(config: TransformerEncoderConfig) {
         let [batch_size, seq_length, d_model] = [3, 4, config.d_model];
-        let transformer = TransformerEncoder::new(&config);
+        let transformer = config.init();
 
         let tensor = Tensor::<TestBackend, 3>::random(
             [batch_size, seq_length, d_model],

--- a/burn-core/src/nn/transformer/encoder.rs
+++ b/burn-core/src/nn/transformer/encoder.rs
@@ -151,10 +151,9 @@ struct TransformerEncoderLayer<B: Backend> {
 
 impl<B: Backend> TransformerEncoderLayer<B> {
     fn new(config: &TransformerEncoderConfig) -> Self {
-        let config_mha = MultiHeadAttentionConfig::new(config.d_model, config.n_heads)
-            .with_dropout(config.dropout);
-
-        let mha = MultiHeadAttention::new(&config_mha);
+        let mha = MultiHeadAttentionConfig::new(config.d_model, config.n_heads)
+            .with_dropout(config.dropout)
+            .init();
         let norm_1 = LayerNormConfig::new(config.d_model).init();
         let norm_2 = LayerNormConfig::new(config.d_model).init();
         let dropout = DropoutConfig::new(config.dropout).init();

--- a/burn-core/src/nn/transformer/encoder.rs
+++ b/burn-core/src/nn/transformer/encoder.rs
@@ -151,7 +151,6 @@ struct TransformerEncoderLayer<B: Backend> {
 impl<B: Backend> TransformerEncoderLayer<B> {
     fn new(config: &TransformerEncoderConfig) -> Self {
         let config_norm = LayerNormConfig::new(config.d_model);
-        let config_dropout = DropoutConfig::new(config.dropout);
         let config_mha = MultiHeadAttentionConfig::new(config.d_model, config.n_heads)
             .with_dropout(config.dropout);
         let config_pwff = PositionWiseFeedForwardConfig::new(config.d_model, config.d_ff)
@@ -160,7 +159,7 @@ impl<B: Backend> TransformerEncoderLayer<B> {
         let mha = MultiHeadAttention::new(&config_mha);
         let norm_1 = LayerNorm::new(&config_norm);
         let norm_2 = LayerNorm::new(&config_norm);
-        let dropout = Dropout::new(&config_dropout);
+        let dropout = DropoutConfig::new(config.dropout).init();
         let pwff = PositionWiseFeedForward::new(&config_pwff);
 
         Self {

--- a/burn-core/src/nn/transformer/pwff.rs
+++ b/burn-core/src/nn/transformer/pwff.rs
@@ -39,8 +39,8 @@ impl<B: Backend> PositionWiseFeedForward<B> {
     /// Create the module from the given configuration.
     pub fn new(config: &PositionWiseFeedForwardConfig) -> Self {
         Self {
-            linear_inner: Param::from(Linear::new(&LinearConfig::new(config.d_model, config.d_ff))),
-            linear_outer: Param::from(Linear::new(&LinearConfig::new(config.d_ff, config.d_model))),
+            linear_inner: Param::from(LinearConfig::new(config.d_model, config.d_ff).init()),
+            linear_outer: Param::from(LinearConfig::new(config.d_ff, config.d_model).init()),
             dropout: Dropout::new(&DropoutConfig::new(config.dropout)),
             gelu: GELU::new(),
         }

--- a/burn-core/src/nn/transformer/pwff.rs
+++ b/burn-core/src/nn/transformer/pwff.rs
@@ -41,7 +41,7 @@ impl<B: Backend> PositionWiseFeedForward<B> {
         Self {
             linear_inner: Param::from(LinearConfig::new(config.d_model, config.d_ff).init()),
             linear_outer: Param::from(LinearConfig::new(config.d_ff, config.d_model).init()),
-            dropout: Dropout::new(&DropoutConfig::new(config.dropout)),
+            dropout: DropoutConfig::new(config.dropout).init(),
             gelu: GELU::new(),
         }
     }

--- a/burn-core/src/nn/transformer/pwff.rs
+++ b/burn-core/src/nn/transformer/pwff.rs
@@ -35,17 +35,19 @@ pub struct PositionWiseFeedForward<B: Backend> {
     gelu: GELU,
 }
 
-impl<B: Backend> PositionWiseFeedForward<B> {
-    /// Create the module from the given configuration.
-    pub fn new(config: &PositionWiseFeedForwardConfig) -> Self {
-        Self {
-            linear_inner: Param::from(LinearConfig::new(config.d_model, config.d_ff).init()),
-            linear_outer: Param::from(LinearConfig::new(config.d_ff, config.d_model).init()),
-            dropout: DropoutConfig::new(config.dropout).init(),
+impl PositionWiseFeedForwardConfig {
+    /// Initialize a new [position-wise feed-forward](PositionWiseFeedForward) module.
+    pub fn init<B: Backend>(&self) -> PositionWiseFeedForward<B> {
+        PositionWiseFeedForward {
+            linear_inner: Param::from(LinearConfig::new(self.d_model, self.d_ff).init()),
+            linear_outer: Param::from(LinearConfig::new(self.d_ff, self.d_model).init()),
+            dropout: DropoutConfig::new(self.dropout).init(),
             gelu: GELU::new(),
         }
     }
+}
 
+impl<B: Backend> PositionWiseFeedForward<B> {
     /// Applies the forward pass on the input tensor.
     ///
     /// # Shapes

--- a/burn-core/src/optim/adam.rs
+++ b/burn-core/src/optim/adam.rs
@@ -189,7 +189,7 @@ mod tests {
 
     #[test]
     fn test_adam_optimizer_save_load_state() {
-        let linear = nn::Linear::new(&nn::LinearConfig::new(6, 6));
+        let linear = nn::LinearConfig::new(6, 6).init();
         let x = Tensor::<TestADBackend, 2>::random([2, 6], Distribution::Standard);
         let mut optimizer = Adam::new(&AdamConfig::new(0.01));
         let grads = linear.forward(x).backward();
@@ -262,7 +262,7 @@ mod tests {
     }
 
     fn given_linear_layer(weight: Data<f32, 2>, bias: Data<f32, 1>) -> nn::Linear<TestADBackend> {
-        let linear = nn::Linear::new(&nn::LinearConfig::new(6, 6));
+        let linear = nn::LinearConfig::new(6, 6).init();
         let state = given_linear_state(weight, bias);
 
         linear.load(&state).unwrap()

--- a/burn-core/src/optim/grad_accum.rs
+++ b/burn-core/src/optim/grad_accum.rs
@@ -106,7 +106,7 @@ mod tests {
     }
 
     fn layer() -> Linear<TestADBackend> {
-        Linear::<TestADBackend>::new(&LinearConfig::new(20, 20).with_bias(true))
+        LinearConfig::new(20, 20).with_bias(true).init()
     }
 
     fn random_tensor() -> Tensor<TestADBackend, 2> {

--- a/burn-core/src/optim/grads.rs
+++ b/burn-core/src/optim/grads.rs
@@ -117,7 +117,7 @@ mod tests {
     }
 
     fn layer() -> Linear<TestADBackend> {
-        Linear::<TestADBackend>::new(&LinearConfig::new(20, 20).with_bias(true))
+        LinearConfig::new(20, 20).with_bias(true).init()
     }
 
     fn random_tensor() -> Tensor<TestADBackend, 2> {

--- a/burn-core/src/optim/sgd.rs
+++ b/burn-core/src/optim/sgd.rs
@@ -170,7 +170,7 @@ mod tests {
     }
 
     fn layer() -> Linear<TestADBackend> {
-        Linear::<TestADBackend>::new(&LinearConfig::new(20, 20).with_bias(true))
+        LinearConfig::new(20, 20).with_bias(true).init()
     }
 
     fn sgd_with_all() -> Sgd<TestADBackend> {

--- a/burn-no-std-tests/src/conv.rs
+++ b/burn-no-std-tests/src/conv.rs
@@ -25,10 +25,9 @@ pub struct ConvBlockConfig {
 
 impl<B: Backend> ConvBlock<B> {
     pub fn new(config: &ConvBlockConfig) -> Self {
-        let conv = nn::conv::Conv2d::new(
-            &nn::conv::Conv2dConfig::new(config.channels, config.kernel_size)
-                .with_padding(nn::conv::Conv2dPaddingConfig::Same),
-        );
+        let conv = nn::conv::Conv2dConfig::new(config.channels, config.kernel_size)
+            .with_padding(nn::conv::Conv2dPaddingConfig::Same)
+            .init();
         let pool = nn::pool::MaxPool2dConfig::new(config.channels[1], config.kernel_size)
             .with_padding(nn::conv::Conv2dPaddingConfig::Same)
             .init();

--- a/burn-no-std-tests/src/conv.rs
+++ b/burn-no-std-tests/src/conv.rs
@@ -29,10 +29,9 @@ impl<B: Backend> ConvBlock<B> {
             &nn::conv::Conv2dConfig::new(config.channels, config.kernel_size)
                 .with_padding(nn::conv::Conv2dPaddingConfig::Same),
         );
-        let pool = nn::pool::MaxPool2d::new(
-            &nn::pool::MaxPool2dConfig::new(config.channels[1], config.kernel_size)
-                .with_padding(nn::conv::Conv2dPaddingConfig::Same),
-        );
+        let pool = nn::pool::MaxPool2dConfig::new(config.channels[1], config.kernel_size)
+            .with_padding(nn::conv::Conv2dPaddingConfig::Same)
+            .init();
         let activation = nn::GELU::new();
 
         Self {

--- a/burn-no-std-tests/src/mlp.rs
+++ b/burn-no-std-tests/src/mlp.rs
@@ -37,8 +37,7 @@ impl<B: Backend> Mlp<B> {
         let mut linears = Vec::with_capacity(config.num_layers);
 
         for _ in 0..config.num_layers {
-            let linear = nn::Linear::new(&nn::LinearConfig::new(config.d_model, config.d_model));
-            linears.push(linear);
+            linears.push(nn::LinearConfig::new(config.d_model, config.d_model).init());
         }
 
         Self {

--- a/burn-no-std-tests/src/mlp.rs
+++ b/burn-no-std-tests/src/mlp.rs
@@ -42,7 +42,7 @@ impl<B: Backend> Mlp<B> {
 
         Self {
             linears: Param::from(linears),
-            dropout: nn::Dropout::new(&nn::DropoutConfig::new(0.3)),
+            dropout: nn::DropoutConfig::new(0.3).init(),
             activation: nn::ReLU::new(),
         }
     }

--- a/burn-no-std-tests/src/model.rs
+++ b/burn-no-std-tests/src/model.rs
@@ -41,16 +41,8 @@ impl<B: Backend> Model<B> {
     pub fn new(config: &MnistConfig) -> Self {
         let mlp = Mlp::new(&config.mlp);
 
-        let input = nn::Linear::new(&nn::LinearConfig::new(
-            config.input_size,
-            config.mlp.d_model,
-        ));
-
-        let output = nn::Linear::new(&nn::LinearConfig::new(
-            config.mlp.d_model,
-            config.output_size,
-        ));
-
+        let input = nn::LinearConfig::new(config.input_size, config.mlp.d_model).init();
+        let output = nn::LinearConfig::new(config.mlp.d_model, config.output_size).init();
         let conv = ConvBlock::new(&ConvBlockConfig::new([1, 1]));
 
         Self {

--- a/burn-tensor/src/tensor/data.rs
+++ b/burn-tensor/src/tensor/data.rs
@@ -231,6 +231,19 @@ impl<E: Into<f64> + Clone + core::fmt::Debug + PartialEq, const D: usize> Data<E
             assert_eq!(self.value, other.value);
         }
     }
+
+    pub fn assert_in_range(&self, min: E, max: E) {
+        let min: f64 = min.into();
+        let max: f64 = max.into();
+
+        for item in self.value.iter() {
+            let item: f64 = item.clone().into();
+
+            if item < min || item > max {
+                panic!("Element ({item}) is not within the range of ({min},{max})");
+            }
+        }
+    }
 }
 
 impl<const D: usize> Data<usize, D> {

--- a/examples/mnist-inference-web/src/model.rs
+++ b/examples/mnist-inference-web/src/model.rs
@@ -29,8 +29,12 @@ impl<B: Backend> Model<B> {
         let conv3 = ConvBlock::new([16, 24], [3, 3]); // out: [Batch,24,22x22]
 
         let hidden_size = 24 * 22 * 22;
-        let fc1 = nn::Linear::new(&nn::LinearConfig::new(hidden_size, 32).with_bias(false));
-        let fc2 = nn::Linear::new(&nn::LinearConfig::new(32, NUM_CLASSES).with_bias(false));
+        let fc1 = nn::LinearConfig::new(hidden_size, 32)
+            .with_bias(false)
+            .init();
+        let fc2 = nn::LinearConfig::new(32, NUM_CLASSES)
+            .with_bias(false)
+            .init();
 
         Self {
             conv1: Param::from(conv1),

--- a/examples/mnist-inference-web/src/model.rs
+++ b/examples/mnist-inference-web/src/model.rs
@@ -73,10 +73,9 @@ pub struct ConvBlock<B: Backend> {
 
 impl<B: Backend> ConvBlock<B> {
     pub fn new(channels: [usize; 2], kernel_size: [usize; 2]) -> Self {
-        let conv = nn::conv::Conv2d::new(
-            &nn::conv::Conv2dConfig::new(channels, kernel_size)
-                .with_padding(Conv2dPaddingConfig::Valid),
-        );
+        let conv = nn::conv::Conv2dConfig::new(channels, kernel_size)
+            .with_padding(Conv2dPaddingConfig::Valid)
+            .init();
         let norm = nn::BatchNormConfig::new(channels[1]).init();
 
         Self {

--- a/examples/mnist-inference-web/src/model.rs
+++ b/examples/mnist-inference-web/src/model.rs
@@ -77,7 +77,7 @@ impl<B: Backend> ConvBlock<B> {
             &nn::conv::Conv2dConfig::new(channels, kernel_size)
                 .with_padding(Conv2dPaddingConfig::Valid),
         );
-        let norm = nn::BatchNorm::new(&nn::BatchNormConfig::new(channels[1]));
+        let norm = nn::BatchNormConfig::new(channels[1]).init();
 
         Self {
             conv: Param::from(conv),

--- a/examples/mnist/src/model.rs
+++ b/examples/mnist/src/model.rs
@@ -36,7 +36,7 @@ impl<B: Backend> Model<B> {
             .with_bias(false)
             .init();
 
-        let dropout = nn::Dropout::new(&nn::DropoutConfig::new(0.3));
+        let dropout = nn::DropoutConfig::new(0.3).init();
 
         Self {
             conv1: Param::from(conv1),

--- a/examples/mnist/src/model.rs
+++ b/examples/mnist/src/model.rs
@@ -29,8 +29,12 @@ impl<B: Backend> Model<B> {
         let conv2 = ConvBlock::new([8, 16], [3, 3]); // out: [Batch,16,24x24]
         let conv3 = ConvBlock::new([16, 24], [3, 3]); // out: [Batch,24,22x22]
         let hidden_size = 24 * 22 * 22;
-        let fc1 = nn::Linear::new(&nn::LinearConfig::new(hidden_size, 32).with_bias(false));
-        let fc2 = nn::Linear::new(&nn::LinearConfig::new(32, NUM_CLASSES).with_bias(false));
+        let fc1 = nn::LinearConfig::new(hidden_size, 32)
+            .with_bias(false)
+            .init();
+        let fc2 = nn::LinearConfig::new(32, NUM_CLASSES)
+            .with_bias(false)
+            .init();
 
         let dropout = nn::Dropout::new(&nn::DropoutConfig::new(0.3));
 

--- a/examples/mnist/src/model.rs
+++ b/examples/mnist/src/model.rs
@@ -94,7 +94,7 @@ impl<B: Backend> ConvBlock<B> {
             &nn::conv::Conv2dConfig::new(channels, kernel_size)
                 .with_padding(Conv2dPaddingConfig::Valid),
         );
-        let norm = nn::BatchNorm::new(&nn::BatchNormConfig::new(channels[1]));
+        let norm = nn::BatchNormConfig::new(channels[1]).init();
 
         Self {
             conv: Param::from(conv),

--- a/examples/mnist/src/model.rs
+++ b/examples/mnist/src/model.rs
@@ -90,10 +90,9 @@ pub struct ConvBlock<B: Backend> {
 
 impl<B: Backend> ConvBlock<B> {
     pub fn new(channels: [usize; 2], kernel_size: [usize; 2]) -> Self {
-        let conv = nn::conv::Conv2d::new(
-            &nn::conv::Conv2dConfig::new(channels, kernel_size)
-                .with_padding(Conv2dPaddingConfig::Valid),
-        );
+        let conv = nn::conv::Conv2dConfig::new(channels, kernel_size)
+            .with_padding(Conv2dPaddingConfig::Valid)
+            .init();
         let norm = nn::BatchNormConfig::new(channels[1]).init();
 
         Self {

--- a/examples/text-classification/src/model.rs
+++ b/examples/text-classification/src/model.rs
@@ -36,12 +36,11 @@ impl<B: Backend> TextClassificationModel<B> {
             EmbeddingConfig::new(config.vocab_size, config.transformer.d_model);
         let config_embedding_pos =
             EmbeddingConfig::new(config.max_seq_length, config.transformer.d_model);
-        let config_output = LinearConfig::new(config.transformer.d_model, config.n_classes);
+        let output = LinearConfig::new(config.transformer.d_model, config.n_classes).init();
 
         let transformer = TransformerEncoder::new(&config.transformer);
         let embedding_token = Embedding::new(&config_embedding_token);
         let embedding_pos = Embedding::new(&config_embedding_pos);
-        let output = Linear::new(&config_output);
 
         Self {
             transformer: Param::from(transformer),

--- a/examples/text-classification/src/model.rs
+++ b/examples/text-classification/src/model.rs
@@ -32,15 +32,12 @@ pub struct TextClassificationModel<B: Backend> {
 
 impl<B: Backend> TextClassificationModel<B> {
     pub fn new(config: &TextClassificationModelConfig) -> Self {
-        let config_embedding_token =
-            EmbeddingConfig::new(config.vocab_size, config.transformer.d_model);
-        let config_embedding_pos =
-            EmbeddingConfig::new(config.max_seq_length, config.transformer.d_model);
         let output = LinearConfig::new(config.transformer.d_model, config.n_classes).init();
-
         let transformer = TransformerEncoder::new(&config.transformer);
-        let embedding_token = Embedding::new(&config_embedding_token);
-        let embedding_pos = Embedding::new(&config_embedding_pos);
+        let embedding_token =
+            EmbeddingConfig::new(config.vocab_size, config.transformer.d_model).init();
+        let embedding_pos =
+            EmbeddingConfig::new(config.max_seq_length, config.transformer.d_model).init();
 
         Self {
             transformer: Param::from(transformer),

--- a/examples/text-classification/src/model.rs
+++ b/examples/text-classification/src/model.rs
@@ -30,25 +30,27 @@ pub struct TextClassificationModel<B: Backend> {
     max_seq_length: usize,
 }
 
-impl<B: Backend> TextClassificationModel<B> {
-    pub fn new(config: &TextClassificationModelConfig) -> Self {
-        let output = LinearConfig::new(config.transformer.d_model, config.n_classes).init();
-        let transformer = config.transformer.init();
+impl TextClassificationModelConfig {
+    pub fn init<B: Backend>(&self) -> TextClassificationModel<B> {
+        let output = LinearConfig::new(self.transformer.d_model, self.n_classes).init();
+        let transformer = self.transformer.init();
         let embedding_token =
-            EmbeddingConfig::new(config.vocab_size, config.transformer.d_model).init();
+            EmbeddingConfig::new(self.vocab_size, self.transformer.d_model).init();
         let embedding_pos =
-            EmbeddingConfig::new(config.max_seq_length, config.transformer.d_model).init();
+            EmbeddingConfig::new(self.max_seq_length, self.transformer.d_model).init();
 
-        Self {
+        TextClassificationModel {
             transformer: Param::from(transformer),
             embedding_token: Param::from(embedding_token),
             embedding_pos: Param::from(embedding_pos),
             output: Param::from(output),
-            n_classes: config.n_classes,
-            max_seq_length: config.max_seq_length,
+            n_classes: self.n_classes,
+            max_seq_length: self.max_seq_length,
         }
     }
+}
 
+impl<B: Backend> TextClassificationModel<B> {
     pub fn forward(&self, item: TextClassificationBatch<B>) -> ClassificationOutput<B> {
         let [batch_size, seq_length] = item.tokens.dims();
         let device = &self.embedding_token.devices()[0];

--- a/examples/text-classification/src/model.rs
+++ b/examples/text-classification/src/model.rs
@@ -33,7 +33,7 @@ pub struct TextClassificationModel<B: Backend> {
 impl<B: Backend> TextClassificationModel<B> {
     pub fn new(config: &TextClassificationModelConfig) -> Self {
         let output = LinearConfig::new(config.transformer.d_model, config.n_classes).init();
-        let transformer = TransformerEncoder::new(&config.transformer);
+        let transformer = config.transformer.init();
         let embedding_token =
             EmbeddingConfig::new(config.vocab_size, config.transformer.d_model).init();
         let embedding_pos =

--- a/examples/text-classification/src/training.rs
+++ b/examples/text-classification/src/training.rs
@@ -1,6 +1,6 @@
 use crate::{
     data::{BertCasedTokenizer, TextClassificationBatcher, TextClassificationDataset, Tokenizer},
-    model::{TextClassificationModel, TextClassificationModelConfig},
+    model::TextClassificationModelConfig,
 };
 use burn::{
     config::Config,
@@ -51,12 +51,13 @@ pub fn train<B: ADBackend, D: TextClassificationDataset + 'static>(
         config.max_seq_length,
     ));
 
-    let model = TextClassificationModel::new(&TextClassificationModelConfig::new(
+    let model = TextClassificationModelConfig::new(
         config.transformer.clone(),
         n_classes,
         tokenizer.vocab_size(),
         config.max_seq_length,
-    ));
+    )
+    .init();
 
     let dataloader_train = DataLoaderBuilder::new(batcher_train)
         .batch_size(config.batch_size)

--- a/examples/text-generation/src/model.rs
+++ b/examples/text-generation/src/model.rs
@@ -38,12 +38,11 @@ impl<B: Backend> TextGenerationModel<B> {
             EmbeddingConfig::new(config.vocab_size, config.transformer.d_model);
         let config_embedding_pos =
             EmbeddingConfig::new(config.max_seq_length, config.transformer.d_model);
-        let config_output = LinearConfig::new(config.transformer.d_model, config.vocab_size);
+        let output = LinearConfig::new(config.transformer.d_model, config.vocab_size).init();
 
         let transformer = TransformerEncoder::new(&config.transformer);
         let embedding_token = Embedding::new(&config_embedding_token);
         let embedding_pos = Embedding::new(&config_embedding_pos);
-        let output = Linear::new(&config_output);
 
         Self {
             transformer: Param::from(transformer),

--- a/examples/text-generation/src/model.rs
+++ b/examples/text-generation/src/model.rs
@@ -34,15 +34,12 @@ pub struct TextGenerationModel<B: Backend> {
 
 impl<B: Backend> TextGenerationModel<B> {
     pub fn new(config: &TextGenerationModelConfig) -> Self {
-        let config_embedding_token =
-            EmbeddingConfig::new(config.vocab_size, config.transformer.d_model);
-        let config_embedding_pos =
-            EmbeddingConfig::new(config.max_seq_length, config.transformer.d_model);
         let output = LinearConfig::new(config.transformer.d_model, config.vocab_size).init();
-
         let transformer = TransformerEncoder::new(&config.transformer);
-        let embedding_token = Embedding::new(&config_embedding_token);
-        let embedding_pos = Embedding::new(&config_embedding_pos);
+        let embedding_token =
+            EmbeddingConfig::new(config.vocab_size, config.transformer.d_model).init();
+        let embedding_pos =
+            EmbeddingConfig::new(config.max_seq_length, config.transformer.d_model).init();
 
         Self {
             transformer: Param::from(transformer),

--- a/examples/text-generation/src/model.rs
+++ b/examples/text-generation/src/model.rs
@@ -35,7 +35,7 @@ pub struct TextGenerationModel<B: Backend> {
 impl<B: Backend> TextGenerationModel<B> {
     pub fn new(config: &TextGenerationModelConfig) -> Self {
         let output = LinearConfig::new(config.transformer.d_model, config.vocab_size).init();
-        let transformer = TransformerEncoder::new(&config.transformer);
+        let transformer = config.transformer.init();
         let embedding_token =
             EmbeddingConfig::new(config.vocab_size, config.transformer.d_model).init();
         let embedding_pos =

--- a/examples/text-generation/src/model.rs
+++ b/examples/text-generation/src/model.rs
@@ -32,26 +32,27 @@ pub struct TextGenerationModel<B: Backend> {
     max_seq_length: usize,
 }
 
-impl<B: Backend> TextGenerationModel<B> {
-    pub fn new(config: &TextGenerationModelConfig) -> Self {
-        let output = LinearConfig::new(config.transformer.d_model, config.vocab_size).init();
-        let transformer = config.transformer.init();
+impl TextGenerationModelConfig {
+    pub fn init<B: Backend>(&self) -> TextGenerationModel<B> {
+        let output = LinearConfig::new(self.transformer.d_model, self.vocab_size).init();
+        let transformer = self.transformer.init();
         let embedding_token =
-            EmbeddingConfig::new(config.vocab_size, config.transformer.d_model).init();
+            EmbeddingConfig::new(self.vocab_size, self.transformer.d_model).init();
         let embedding_pos =
-            EmbeddingConfig::new(config.max_seq_length, config.transformer.d_model).init();
+            EmbeddingConfig::new(self.max_seq_length, self.transformer.d_model).init();
 
-        Self {
+        TextGenerationModel {
             transformer: Param::from(transformer),
             embedding_token: Param::from(embedding_token),
             embedding_pos: Param::from(embedding_pos),
             output: Param::from(output),
-            vocab_size: config.vocab_size,
-            pad_token: config.pad_token,
-            max_seq_length: config.max_seq_length,
+            vocab_size: self.vocab_size,
+            pad_token: self.pad_token,
+            max_seq_length: self.max_seq_length,
         }
     }
-
+}
+impl<B: Backend> TextGenerationModel<B> {
     pub fn forward_training(
         &self,
         item: TrainingTextGenerationBatch<B>,

--- a/examples/text-generation/src/training.rs
+++ b/examples/text-generation/src/training.rs
@@ -1,6 +1,6 @@
 use crate::{
     data::{Gpt2Tokenizer, TextGenerationBatcher, TextGenerationItem, Tokenizer},
-    model::{TextGenerationModel, TextGenerationModelConfig},
+    model::TextGenerationModelConfig,
 };
 use burn::{
     config::Config,
@@ -49,12 +49,13 @@ pub fn train<B: ADBackend, D: Dataset<TextGenerationItem> + 'static>(
         config.max_seq_length,
     ));
 
-    let model = TextGenerationModel::<B>::new(&TextGenerationModelConfig::new(
+    let model = TextGenerationModelConfig::new(
         config.transformer.clone(),
         tokenizer.vocab_size(),
         tokenizer.pad_token(),
         config.max_seq_length,
-    ));
+    )
+    .init::<B>();
 
     let dataloader_train = DataLoaderBuilder::new(batcher_train)
         .batch_size(config.batch_size)


### PR DESCRIPTION
Move the initialization of modules into an `init` method on their config struct. 

Init state should come later when #226 is more advanced.

A potential improvement would be to use a `config` function on the `Module` struct itself instead of using `new` on the `Config` struct.

```rust
let linear = LinearConfig::new(5, 5).with_bias(false).init(); // Now
let linear = Linear::config(5, 5).with_bias(false).init(); // After
```

To do this, we could need to move the `Config` derive to a more powerfull macro:

```rust
#[derive(Config)] // Now
struct LinearConfig {
...
}

#[config(module = "Linear")] // After
struct LinearConfig {
...
}
```

The second macro can receive parameters in it declaration telling us to create an alias function `Linear::config => LinearConfig::new`.