### PR TITLE
Feat: add new tensor ops mask_scatter

### DIFF
--- a/burn-autodiff/src/tests/mask.rs
+++ b/burn-autodiff/src/tests/mask.rs
@@ -4,7 +4,7 @@ mod tests {
     use burn_tensor::Data;
 
     #[test]
-    fn should_diff_mask() {
+    fn should_diff_mask_fill() {
         let data_1 = Data::<f32, 2>::from([[1.0, 7.0], [2.0, 3.0]]);
         let data_2 = Data::<f32, 2>::from([[4.0, 7.0], [2.0, 3.0]]);
         let mask = Data::<bool, 2>::from([[true, false], [false, true]]);
@@ -15,6 +15,30 @@ mod tests {
 
         let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
         let tensor_4 = tensor_3.mask_fill(mask, 2.0);
+        let grads = tensor_4.backward();
+
+        let grad_1 = tensor_1.grad(&grads).unwrap();
+        let grad_2 = tensor_2.grad(&grads).unwrap();
+
+        assert_eq!(grad_1.to_data(), Data::from([[7.0, 3.0], [4.0, 2.0]]));
+        assert_eq!(grad_2.to_data(), Data::from([[2.0, 1.0], [3.0, 7.0]]));
+    }
+
+    #[test]
+    fn should_diff_mask_scatter() {
+        let data_1 = Data::<f32, 2>::from([[1.0, 7.0], [2.0, 3.0]]);
+        let data_2 = Data::<f32, 2>::from([[4.0, 7.0], [2.0, 3.0]]);
+        let mask = Data::<bool, 2>::from([[true, false], [false, true]]);
+
+        let data_source = Data::<f32, 2>::from([[8.8, 8.8], [8.8, 8.8]]);
+
+        let tensor_1 = TestADTensor::from_data(data_1).require_grad();
+        let tensor_2 = TestADTensor::from_data(data_2).require_grad();
+        let tensor_source = TestADTensor::from_data(data_source);
+        let mask = TestADTensor::from_bool(mask);
+
+        let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
+        let tensor_4 = tensor_3.mask_scatter(mask, tensor_source);
         let grads = tensor_4.backward();
 
         let grad_1 = tensor_1.grad(&grads).unwrap();

--- a/burn-core/src/module/state.rs
+++ b/burn-core/src/module/state.rs
@@ -251,7 +251,7 @@ mod std_enabled {
             let writer = str2writer!(file, "bin.gz")?;
             let mut writer = GzEncoder::new(writer, Compression::default());
 
-            bincode::serde::encode_into_std_write(&self, &mut writer, config).unwrap();
+            bincode::serde::encode_into_std_write(self, &mut writer, config).unwrap();
 
             Ok(())
         }

--- a/burn-ndarray/src/ops/tensor.rs
+++ b/burn-ndarray/src/ops/tensor.rs
@@ -198,6 +198,24 @@ impl<E: FloatNdArrayElement> TensorOps<NdArrayBackend<E>> for NdArrayBackend<E> 
         NdArrayOps::index_assign(tensor, indexes, value)
     }
 
+    fn mask_scatter<const D: usize>(
+        tensor: NdArrayTensor<E, D>,
+        mask: NdArrayTensor<bool, D>,
+        source: NdArrayTensor<E, D>,
+    ) -> NdArrayTensor<E, D> {
+        let mask_mul_4tensor = mask.array.mapv(|x| match x {
+            true => 0.elem(),
+            false => 1.elem(),
+        });
+        let mask_mul_4source = mask.array.mapv(|x| match x {
+            true => 1.elem(),
+            false => 0.elem(),
+        });
+        let array = (tensor.array * mask_mul_4tensor) + (source.array * mask_mul_4source);
+
+        NdArrayTensor::new(array)
+    }
+
     fn mask_fill<const D: usize>(
         tensor: NdArrayTensor<E, D>,
         mask: NdArrayTensor<bool, D>,

--- a/burn-tch/src/ops/tensor.rs
+++ b/burn-tch/src/ops/tensor.rs
@@ -221,6 +221,20 @@ impl<E: TchElement> TensorOps<TchBackend<E>> for TchBackend<E> {
         TchOps::index_assign(tensor, indexes, value)
     }
 
+    fn mask_scatter<const D: usize>(
+        tensor: TchTensor<E, D>,
+        mask: TchTensor<bool, D>,
+        source: TchTensor<E, D>,
+    ) -> TchTensor<E, D> {
+        TchTensor::binary_ops_tensor(
+            tensor,
+            source,
+            |tensor, source| tensor.f_masked_scatter_(&mask.tensor, source).unwrap(),
+            |tensor, source| tensor.f_masked_scatter(&mask.tensor, source).unwrap(),
+            |tensor, source| tensor.f_masked_scatter(&mask.tensor, source).unwrap(),
+        )
+    }
+
     fn mask_fill<const D: usize>(
         tensor: TchTensor<E, D>,
         mask: TchTensor<bool, D>,

--- a/burn-tensor/src/tensor/api/float.rs
+++ b/burn-tensor/src/tensor/api/float.rs
@@ -241,6 +241,15 @@ where
         Self::new(tensor)
     }
 
+    /// Fill elements from the given tensor based where the mask is true.
+    pub fn mask_scatter(self, mask: Tensor<B, D, Bool>, source: Tensor<B, D>) -> Self {
+        Self::new(B::mask_scatter(
+            self.primitive,
+            mask.primitive,
+            source.primitive,
+        ))
+    }
+
     /// Fill each element with the given value based on the given mask.
     pub fn mask_fill<E: ElementConversion>(self, mask: Tensor<B, D, Bool>, value: E) -> Self {
         Self::new(B::mask_fill(self.primitive, mask.primitive, value.elem()))

--- a/burn-tensor/src/tensor/ops/tensor.rs
+++ b/burn-tensor/src/tensor/ops/tensor.rs
@@ -144,6 +144,11 @@ pub trait TensorOps<B: Backend> {
         indexes: [Range<usize>; D2],
         value: B::TensorPrimitive<D1>,
     ) -> B::TensorPrimitive<D1>;
+    fn mask_scatter<const D: usize>(
+        tensor: B::TensorPrimitive<D>,
+        mask: B::BoolTensorPrimitive<D>,
+        source: B::TensorPrimitive<D>,
+    ) -> B::TensorPrimitive<D>;
     fn mask_fill<const D: usize>(
         tensor: B::TensorPrimitive<D>,
         mask: B::BoolTensorPrimitive<D>,

--- a/burn-tensor/src/tests/ops/mask.rs
+++ b/burn-tensor/src/tests/ops/mask.rs
@@ -4,7 +4,21 @@ mod tests {
     use burn_tensor::{Bool, Data, Tensor};
 
     #[test]
-    fn should_support_mask_ops() {
+    fn should_support_mask_scatter_ops() {
+        let tensor = Tensor::<TestBackend, 2>::from_data(Data::from([[1.0, 7.0], [2.0, 3.0]]));
+        let mask =
+            Tensor::<TestBackend, 2, Bool>::from_bool(Data::from([[true, false], [false, true]]));
+
+        let source = Tensor::<TestBackend, 2>::from_data(Data::from([[8.8, 8.8], [8.8, 8.8]]));
+
+        let data_actual = tensor.mask_scatter(mask, source).to_data();
+
+        let data_expected = Data::from([[8.8, 7.0], [2.0, 8.8]]);
+        assert_eq!(data_expected, data_actual);
+    }
+
+    #[test]
+    fn should_support_mask_fill_ops() {
         let tensor = Tensor::<TestBackend, 2>::from_data(Data::from([[1.0, 7.0], [2.0, 3.0]]));
         let mask =
             Tensor::<TestBackend, 2, Bool>::from_bool(Data::from([[true, false], [false, true]]));


### PR DESCRIPTION
Since there's no operation for filling elements by values from another tensor by mask, which will be needed for implementation of softplus, I have written this new operation.

However, considering my poor experience with automatic differentiation, please be careful with the mathematical details this time.