### PR TITLE
Add init_with for nn modules

### DIFF
--- a/burn-core/src/module/param/running.rs
+++ b/burn-core/src/module/param/running.rs
@@ -101,6 +101,15 @@ impl<const D: usize, B: Backend> RunningState<Tensor<B, D>> {
         }
     }
 
+    /// Create a new running state from a record.
+    pub fn from_record(record: Param<Tensor<B, D>>) -> Self {
+        Self {
+            id: record.id,
+            values: Arc::new(Mutex::new(HashMap::new())),
+            value: Arc::new(RwLock::new(record.value)),
+        }
+    }
+
     /// Update the value on the current thread.
     pub fn update(&self, value: Tensor<B, D>) {
         let thread_id = get_thread_current_id();

--- a/burn-core/src/nn/attention/mha.rs
+++ b/burn-core/src/nn/attention/mha.rs
@@ -74,6 +74,29 @@ impl MultiHeadAttentionConfig {
             min_float: self.min_float,
         }
     }
+
+    /// Initialize a new [multihead attention](MultiHeadAttention) module with a
+    /// [record](MultiHeadAttentionRecord).
+    pub fn init_with<B: Backend>(
+        &self,
+        record: MultiHeadAttentionRecord<B>,
+    ) -> MultiHeadAttention<B> {
+        let linear = |config: &Self, record| {
+            nn::LinearConfig::new(config.d_model, config.d_model).init_with(record)
+        };
+
+        MultiHeadAttention {
+            query: linear(self, record.query),
+            key: linear(self, record.key),
+            value: linear(self, record.value),
+            output: linear(self, record.output),
+            dropout: nn::DropoutConfig::new(self.dropout).init(),
+            activation: nn::GELU::new(),
+            n_heads: self.n_heads,
+            d_k: self.d_model / self.n_heads,
+            min_float: self.min_float,
+        }
+    }
 }
 
 impl<B: Backend> MhaInput<B> {

--- a/burn-core/src/nn/conv/conv1d.rs
+++ b/burn-core/src/nn/conv/conv1d.rs
@@ -86,6 +86,16 @@ impl Conv1dConfig {
             padding: self.padding.clone(),
         }
     }
+    /// Initialize a new [conv1d](Conv1d) module with a [record](Conv1dRecord).
+    pub fn init_with<B: Backend>(&self, record: Conv1dRecord<B>) -> Conv1d<B> {
+        Conv1d {
+            weight: record.weight,
+            bias: record.bias,
+            stride: 1, // TODO: Add the stride to the config when properly supported.
+            kernel_size: self.kernel_size,
+            padding: self.padding.clone(),
+        }
+    }
 }
 
 impl<B: Backend> Conv1d<B> {

--- a/burn-core/src/nn/conv/conv2d.rs
+++ b/burn-core/src/nn/conv/conv2d.rs
@@ -92,6 +92,17 @@ impl Conv2dConfig {
             padding: self.padding.clone(),
         }
     }
+
+    /// Initialize a new [conv2d](Conv2d) module with a [record](Conv2dRecord).
+    pub fn init_with<B: Backend>(&self, record: Conv2dRecord<B>) -> Conv2d<B> {
+        Conv2d {
+            weight: record.weight,
+            bias: record.bias,
+            stride: [1, 1], // TODO: Add the stride to the config when properly supported.
+            kernel_size: self.kernel_size,
+            padding: self.padding.clone(),
+        }
+    }
 }
 
 impl<B: Backend> Conv2d<B> {

--- a/burn-core/src/nn/embedding.rs
+++ b/burn-core/src/nn/embedding.rs
@@ -43,6 +43,12 @@ impl EmbeddingConfig {
             weight: Param::from(weight),
         }
     }
+    /// Initialize a new [embedding](Embedding) module with a [record](EmbeddingRecord).
+    pub fn init_with<B: Backend>(&self, record: EmbeddingRecord<B>) -> Embedding<B> {
+        Embedding {
+            weight: record.weight,
+        }
+    }
 }
 
 impl<B: Backend> Embedding<B> {

--- a/burn-core/src/nn/linear.rs
+++ b/burn-core/src/nn/linear.rs
@@ -65,6 +65,14 @@ impl LinearConfig {
             bias: bias.map(Param::from),
         }
     }
+
+    /// Initialize a new [linear](Linear) module with a [record](LinearRecord).
+    pub fn init_with<B: Backend>(&self, record: LinearRecord<B>) -> Linear<B> {
+        Linear {
+            weight: record.weight,
+            bias: record.bias,
+        }
+    }
 }
 
 impl<B: Backend> Linear<B> {

--- a/burn-core/src/nn/norm/batch.rs
+++ b/burn-core/src/nn/norm/batch.rs
@@ -50,6 +50,21 @@ impl BatchNormConfig {
             epsilon: self.epsilon,
         }
     }
+
+    /// Initialize a new [batch norm](BatchNorm) module with a [record](BatchNormRecord).
+    pub fn init_with<B: Backend, const D: usize>(
+        &self,
+        record: BatchNormRecord<B, D>,
+    ) -> BatchNorm<B, D> {
+        BatchNorm {
+            gamma: record.gamma,
+            beta: record.beta,
+            running_mean: RunningState::from_record(record.running_mean),
+            running_var: RunningState::from_record(record.running_var),
+            momentum: self.momentum,
+            epsilon: self.epsilon,
+        }
+    }
 }
 
 impl<const D: usize, B: Backend> BatchNorm<B, D> {

--- a/burn-core/src/nn/norm/layer.rs
+++ b/burn-core/src/nn/norm/layer.rs
@@ -38,6 +38,15 @@ impl LayerNormConfig {
             epsilon: self.epsilon,
         }
     }
+
+    /// Initialize a new [layer norm](LayerNorm) module with a [record](LayerNormRecord).
+    pub fn init_with<B: Backend>(&self, record: LayerNormRecord<B>) -> LayerNorm<B> {
+        LayerNorm {
+            gamma: record.gamma,
+            beta: record.beta,
+            epsilon: self.epsilon,
+        }
+    }
 }
 
 impl<B: Backend> LayerNorm<B> {

--- a/burn-core/src/nn/transformer/pwff.rs
+++ b/burn-core/src/nn/transformer/pwff.rs
@@ -43,6 +43,19 @@ impl PositionWiseFeedForwardConfig {
             gelu: GELU::new(),
         }
     }
+    /// Initialize a new [position-wise feed-forward](PositionWiseFeedForward) module with a
+    /// [record](PositionWiseFeedForwardRecord).
+    pub fn init_with<B: Backend>(
+        &self,
+        record: PositionWiseFeedForwardRecord<B>,
+    ) -> PositionWiseFeedForward<B> {
+        PositionWiseFeedForward {
+            linear_inner: LinearConfig::new(self.d_model, self.d_ff).init_with(record.linear_inner),
+            linear_outer: LinearConfig::new(self.d_ff, self.d_model).init_with(record.linear_outer),
+            dropout: DropoutConfig::new(self.dropout).init(),
+            gelu: GELU::new(),
+        }
+    }
 }
 
 impl<B: Backend> PositionWiseFeedForward<B> {

--- a/examples/text-classification/src/model.rs
+++ b/examples/text-classification/src/model.rs
@@ -48,6 +48,27 @@ impl TextClassificationModelConfig {
             max_seq_length: self.max_seq_length,
         }
     }
+    pub fn init_with<B: Backend>(
+        &self,
+        record: TextClassificationModelRecord<B>,
+    ) -> TextClassificationModel<B> {
+        let output =
+            LinearConfig::new(self.transformer.d_model, self.n_classes).init_with(record.output);
+        let transformer = self.transformer.init_with(record.transformer);
+        let embedding_token = EmbeddingConfig::new(self.vocab_size, self.transformer.d_model)
+            .init_with(record.embedding_token);
+        let embedding_pos = EmbeddingConfig::new(self.max_seq_length, self.transformer.d_model)
+            .init_with(record.embedding_pos);
+
+        TextClassificationModel {
+            transformer,
+            embedding_token,
+            embedding_pos,
+            output,
+            n_classes: self.n_classes,
+            max_seq_length: self.max_seq_length,
+        }
+    }
 }
 
 impl<B: Backend> TextClassificationModel<B> {


### PR DESCRIPTION
The transformer model in the text classification example takes around 200ms less to load the weights and run inference than before. (From 1.2 to 1 second)