### PR TITLE
refactor: burn dataset

### DIFF
--- a/burn-dataset/Cargo.toml
+++ b/burn-dataset/Cargo.toml
@@ -24,5 +24,6 @@ rand = {workspace = true, features = ["std"]}
 serde = {workspace = true, features = ["std", "derive"]}
 serde_json = {workspace = true, features = ["std"]}
 thiserror = {workspace = true}
+derive-new = {workspace = true}
 
 [dev-dependencies]

--- a/burn-dataset/src/dataset/base.rs
+++ b/burn-dataset/src/dataset/base.rs
@@ -1,5 +1,8 @@
+use std::sync::Arc;
+
 use crate::DatasetIterator;
 
+/// The dataset trait defines a basic collection of items with a predefined size.
 pub trait Dataset<I>: Send + Sync {
     fn get(&self, index: usize) -> Option<I>;
     fn len(&self) -> usize;
@@ -11,5 +14,51 @@ pub trait Dataset<I>: Send + Sync {
         Self: Sized,
     {
         DatasetIterator::new(self)
+    }
+}
+
+impl<D, I> Dataset<I> for Arc<D>
+where
+    D: Dataset<I>,
+{
+    fn get(&self, index: usize) -> Option<I> {
+        self.as_ref().get(index)
+    }
+
+    fn len(&self) -> usize {
+        self.as_ref().len()
+    }
+}
+
+impl<I> Dataset<I> for Arc<dyn Dataset<I>> {
+    fn get(&self, index: usize) -> Option<I> {
+        self.as_ref().get(index)
+    }
+
+    fn len(&self) -> usize {
+        self.as_ref().len()
+    }
+}
+
+impl<D, I> Dataset<I> for Box<D>
+where
+    D: Dataset<I>,
+{
+    fn get(&self, index: usize) -> Option<I> {
+        self.as_ref().get(index)
+    }
+
+    fn len(&self) -> usize {
+        self.as_ref().len()
+    }
+}
+
+impl<I> Dataset<I> for Box<dyn Dataset<I>> {
+    fn get(&self, index: usize) -> Option<I> {
+        self.as_ref().get(index)
+    }
+
+    fn len(&self) -> usize {
+        self.as_ref().len()
     }
 }

--- a/burn-dataset/src/dataset/fake.rs
+++ b/burn-dataset/src/dataset/fake.rs
@@ -1,6 +1,7 @@
 use crate::{Dataset, DatasetIterator, InMemDataset};
 use fake::{Dummy, Fake, Faker};
 
+/// Dataset filled with fake items generated from the [fake](fake) crate.
 pub struct FakeDataset<I> {
     dataset: InMemDataset<I>,
 }

--- a/burn-dataset/src/dataset/in_memory.rs
+++ b/burn-dataset/src/dataset/in_memory.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::Dataset;
 
-/// Dataset where all items are stored in RAM.
+/// Dataset where all items are stored in ram.
 pub struct InMemDataset<I> {
     items: Vec<I>,
 }

--- a/burn-dataset/src/dataset/in_memory.rs
+++ b/burn-dataset/src/dataset/in_memory.rs
@@ -5,6 +5,7 @@ use std::{
 
 use crate::Dataset;
 
+/// Dataset where all items are stored in RAM.
 pub struct InMemDataset<I> {
     items: Vec<I>,
 }

--- a/burn-dataset/src/dataset/iterator.rs
+++ b/burn-dataset/src/dataset/iterator.rs
@@ -1,6 +1,7 @@
 use crate::dataset::Dataset;
 use std::iter::Iterator;
 
+/// Dataset iterator.
 pub struct DatasetIterator<'a, I> {
     current: usize,
     dataset: &'a dyn Dataset<I>,

--- a/burn-dataset/src/lib.rs
+++ b/burn-dataset/src/lib.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate derive_new;
+
 extern crate dirs;
 
 pub mod source;

--- a/burn-dataset/src/transform/composed.rs
+++ b/burn-dataset/src/transform/composed.rs
@@ -1,17 +1,14 @@
 use crate::Dataset;
 
-pub struct ComposedDataset<I> {
-    datasets: Vec<Box<dyn Dataset<I>>>,
+/// Compose multiple datasets together to create a bigger one.
+#[derive(new)]
+pub struct ComposedDataset<D> {
+    datasets: Vec<D>,
 }
 
-impl<I> ComposedDataset<I> {
-    pub fn new(datasets: Vec<Box<dyn Dataset<I>>>) -> Self {
-        Self { datasets }
-    }
-}
-
-impl<I> Dataset<I> for ComposedDataset<I>
+impl<D, I> Dataset<I> for ComposedDataset<D>
 where
+    D: Dataset<I>,
     I: Clone,
 {
     fn get(&self, index: usize) -> Option<I> {

--- a/burn-dataset/src/transform/random.rs
+++ b/burn-dataset/src/transform/random.rs
@@ -1,32 +1,43 @@
 use crate::Dataset;
 use rand::{prelude::SliceRandom, rngs::StdRng, SeedableRng};
-use std::sync::Arc;
+use std::marker::PhantomData;
 
-pub struct ShuffledDataset<I> {
-    dataset: Arc<dyn Dataset<I>>,
+/// Shuffled a dataset, consider using [sampler dataset](crate::transform::SamplerDataset) is you
+/// want a probability distribution that is computed lazily.
+pub struct ShuffledDataset<D, I> {
+    dataset: D,
     indexes: Vec<usize>,
+    input: PhantomData<I>,
 }
 
-impl<I> ShuffledDataset<I> {
-    pub fn new(dataset: Arc<dyn Dataset<I>>, rng: &mut StdRng) -> Self {
+impl<D, I> ShuffledDataset<D, I>
+where
+    D: Dataset<I>,
+{
+    pub fn new(dataset: D, rng: &mut StdRng) -> Self {
         let mut indexes = Vec::with_capacity(dataset.len());
         for i in 0..dataset.len() {
             indexes.push(i);
         }
         indexes.shuffle(rng);
 
-        Self { dataset, indexes }
+        Self {
+            dataset,
+            indexes,
+            input: PhantomData::default(),
+        }
     }
 
-    pub fn with_seed(dataset: Arc<dyn Dataset<I>>, seed: u64) -> Self {
+    pub fn with_seed(dataset: D, seed: u64) -> Self {
         let mut rng = StdRng::seed_from_u64(seed);
         Self::new(dataset, &mut rng)
     }
 }
 
-impl<I> Dataset<I> for ShuffledDataset<I>
+impl<D, I> Dataset<I> for ShuffledDataset<D, I>
 where
-    I: Clone,
+    D: Dataset<I>,
+    I: Clone + Send + Sync,
 {
     fn get(&self, index: usize) -> Option<I> {
         let index = match self.indexes.get(index) {

--- a/examples/mnist/src/training.rs
+++ b/examples/mnist/src/training.rs
@@ -43,6 +43,7 @@ pub fn run<B: ADBackend>(device: B::Device) {
     // Data
     let batcher_train = MNISTBatcher::<B>::new(device.clone());
     let batcher_valid = MNISTBatcher::<B::InnerBackend>::new(device.clone());
+
     let dataloader_train = DataLoaderBuilder::new(batcher_train)
         .batch_size(config.batch_size)
         .shuffle(config.seed)

--- a/examples/mnist/src/training.rs
+++ b/examples/mnist/src/training.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::data::MNISTBatcher;
 use crate::model::Model;
 
@@ -43,18 +41,18 @@ pub fn run<B: ADBackend>(device: B::Device) {
     B::seed(config.seed);
 
     // Data
-    let batcher_train = Arc::new(MNISTBatcher::<B>::new(device.clone()));
-    let batcher_valid = Arc::new(MNISTBatcher::<B::InnerBackend>::new(device.clone()));
+    let batcher_train = MNISTBatcher::<B>::new(device.clone());
+    let batcher_valid = MNISTBatcher::<B::InnerBackend>::new(device.clone());
     let dataloader_train = DataLoaderBuilder::new(batcher_train)
         .batch_size(config.batch_size)
         .shuffle(config.seed)
         .num_workers(config.num_workers)
-        .build(Arc::new(MNISTDataset::train()));
+        .build(MNISTDataset::train());
     let dataloader_test = DataLoaderBuilder::new(batcher_valid)
         .batch_size(config.batch_size)
         .shuffle(config.seed)
         .num_workers(config.num_workers)
-        .build(Arc::new(MNISTDataset::test()));
+        .build(MNISTDataset::test());
 
     // Model
     let learner = LearnerBuilder::new(ARTIFACT_DIR)

--- a/examples/text-generation/src/training.rs
+++ b/examples/text-generation/src/training.rs
@@ -40,18 +40,9 @@ pub fn train<B: ADBackend, D: Dataset<TextGenerationItem> + 'static>(
     config: ExperimentConfig,
     artifact_dir: &str,
 ) {
-    let dataset_train = Arc::new(SamplerDataset::new(Box::new(dataset_train), 10_000));
-    let dataset_test = Arc::new(SamplerDataset::new(Box::new(dataset_test), 1000));
-
     let tokenizer = Arc::new(Gpt2Tokenizer::default());
-    let batcher_train = Arc::new(TextGenerationBatcher::new(
-        tokenizer.clone(),
-        config.max_seq_length,
-    ));
-    let batcher_test = Arc::new(TextGenerationBatcher::new(
-        tokenizer.clone(),
-        config.max_seq_length,
-    ));
+    let batcher_train = TextGenerationBatcher::new(tokenizer.clone(), config.max_seq_length);
+    let batcher_test = TextGenerationBatcher::new(tokenizer.clone(), config.max_seq_length);
 
     let model = TextGenerationModelConfig::new(
         config.transformer.clone(),
@@ -64,12 +55,12 @@ pub fn train<B: ADBackend, D: Dataset<TextGenerationItem> + 'static>(
     let dataloader_train = DataLoaderBuilder::new(batcher_train)
         .batch_size(config.batch_size)
         .num_workers(4)
-        .build(dataset_train);
+        .build(SamplerDataset::new(dataset_train, 10_000));
 
     let dataloader_test = DataLoaderBuilder::new(batcher_test)
         .batch_size(config.batch_size)
         .num_workers(4)
-        .build(dataset_test);
+        .build(SamplerDataset::new(dataset_test, 1000));
 
     let optim = config.optimizer.init();
     let lr_scheduler = ConstantLR::new(2.5e-5);


### PR DESCRIPTION
Remove the necessity of wrapping everything in Arc or Box. If it's required, the builder will do it, which helps reducing verbosity.