### PR TITLE
add burn-tch support for bf16

### DIFF
--- a/burn-tch/src/element.rs
+++ b/burn-tch/src/element.rs
@@ -1,11 +1,12 @@
 use burn_tensor::Element;
-use half::f16;
+use half::{bf16, f16};
 
 pub trait TchElement: Element + tch::kind::Element {}
 
 impl TchElement for f64 {}
 impl TchElement for f32 {}
 impl TchElement for f16 {}
+impl TchElement for bf16 {}
 
 impl TchElement for i64 {}
 impl TchElement for i32 {}

--- a/burn-tensor/src/lib.rs
+++ b/burn-tensor/src/lib.rs
@@ -10,5 +10,5 @@ mod tensor;
 #[cfg(feature = "export_tests")]
 mod tests;
 
-pub use half::f16;
+pub use half::{bf16, f16};
 pub use tensor::*;


### PR DESCRIPTION
`tch` supports bf16, so backends should too. Would like to update ndarray if possible