### PR TITLE
Fix: support broadcast during backward

### DIFF
--- a/burn-autodiff/src/ops/tensor.rs
+++ b/burn-autodiff/src/ops/tensor.rs
@@ -1340,7 +1340,7 @@ fn broadcast_shape<B: Backend, const D: usize>(
     let shape_grad = B::shape(&grad);
 
     for i in 0..D {
-        if shape_grad.dims[i] > shape.dims[i] {
+        if shape_grad.dims[i] != shape.dims[i] {
             if shape.dims[i] != 1 {
                 panic!(
                     "Invalid broadcast shapes: Next grad shape {:?}, Previous grad shape {:?}. {}",

--- a/burn-autodiff/src/ops/tensor.rs
+++ b/burn-autodiff/src/ops/tensor.rs
@@ -87,15 +87,31 @@ impl<B: Backend> TensorOps<ADBackendDecorator<B>> for ADBackendDecorator<B> {
         struct Add;
 
         impl<B: Backend, const D: usize> Backward<B, D, 2> for Add {
-            type State = ();
+            type State = (Shape<D>, Shape<D>);
 
             fn backward(self, ops: Ops<Self::State, 2>, grads: &mut Gradients) {
-                binary::<B, D, D, D, _, _>(ops.parents, ops.node, grads, |grad| grad, |grad| grad);
+                let (shape_lhs, shape_rhs) = ops.state;
+
+                binary::<B, D, D, D, _, _>(
+                    ops.parents,
+                    ops.node,
+                    grads,
+                    |grad| broadcast_shape::<B, D>(grad, shape_lhs),
+                    |grad| broadcast_shape::<B, D>(grad, shape_rhs),
+                );
             }
         }
 
-        Add.prepare([lhs.node, rhs.node], [lhs.graph, rhs.graph])
-            .stateless(B::add(lhs.primitive, rhs.primitive))
+        match Add
+            .prepare([lhs.node, rhs.node], [lhs.graph, rhs.graph])
+            .statefull()
+        {
+            OpsKind::Tracked(preps) => preps.finish(
+                (B::shape(&lhs.primitive), B::shape(&rhs.primitive)),
+                B::add(lhs.primitive, rhs.primitive),
+            ),
+            OpsKind::UnTracked(preps) => preps.finish(B::add(lhs.primitive, rhs.primitive)),
+        }
     }
 
     fn add_scalar<const D: usize>(lhs: ADTensor<B, D>, rhs: FloatElem<B>) -> ADTensor<B, D> {
@@ -120,21 +136,31 @@ impl<B: Backend> TensorOps<ADBackendDecorator<B>> for ADBackendDecorator<B> {
         struct Sub;
 
         impl<B: Backend, const D: usize> Backward<B, D, 2> for Sub {
-            type State = ();
+            type State = (Shape<D>, Shape<D>);
 
             fn backward(self, ops: Ops<Self::State, 2>, grads: &mut Gradients) {
+                let (shape_lhs, shape_rhs) = ops.state;
+
                 binary::<B, D, D, D, _, _>(
                     ops.parents,
                     ops.node,
                     grads,
-                    |grad| grad,
-                    |grad| B::neg(grad),
+                    |grad| broadcast_shape::<B, D>(grad, shape_lhs),
+                    |grad| broadcast_shape::<B, D>(B::neg(grad), shape_rhs),
                 );
             }
         }
 
-        Sub.prepare([lhs.node, rhs.node], [lhs.graph, rhs.graph])
-            .stateless(B::sub(lhs.primitive, rhs.primitive))
+        match Sub
+            .prepare([lhs.node, rhs.node], [lhs.graph, rhs.graph])
+            .statefull()
+        {
+            OpsKind::Tracked(preps) => preps.finish(
+                (B::shape(&lhs.primitive), B::shape(&rhs.primitive)),
+                B::sub(lhs.primitive, rhs.primitive),
+            ),
+            OpsKind::UnTracked(preps) => preps.finish(B::sub(lhs.primitive, rhs.primitive)),
+        }
     }
 
     fn sub_scalar<const D: usize>(lhs: ADTensor<B, D>, rhs: FloatElem<B>) -> ADTensor<B, D> {
@@ -1301,4 +1327,25 @@ impl<B: Backend> TensorOps<ADBackendDecorator<B>> for ADBackendDecorator<B> {
             OpsKind::UnTracked(prep) => prep.finish(output),
         }
     }
+}
+
+fn broadcast_shape<B: Backend, const D: usize>(
+    mut grad: B::TensorPrimitive<D>,
+    shape: Shape<D>,
+) -> B::TensorPrimitive<D> {
+    let shape_grad = B::shape(&grad);
+
+    for i in 0..D {
+        if shape_grad.dims[i] > shape.dims[i] {
+            if shape.dims[i] != 1 {
+                panic!(
+                    "Invalid broadcast shapes: Next grad shape {:?}, Previous grad shape {:?}",
+                    shape.dims, shape_grad.dims
+                );
+            }
+            grad = B::sum_dim(grad, i);
+        }
+    }
+
+    grad
 }

--- a/burn-autodiff/src/ops/tensor.rs
+++ b/burn-autodiff/src/ops/tensor.rs
@@ -1329,6 +1329,10 @@ impl<B: Backend> TensorOps<ADBackendDecorator<B>> for ADBackendDecorator<B> {
     }
 }
 
+/// Make sure the grad tensor has the given shape.
+///
+/// If broadcasting happened during the forward pass, the gradients will be sum along the
+/// broadcasted dimension.
 fn broadcast_shape<B: Backend, const D: usize>(
     mut grad: B::TensorPrimitive<D>,
     shape: Shape<D>,
@@ -1339,8 +1343,8 @@ fn broadcast_shape<B: Backend, const D: usize>(
         if shape_grad.dims[i] > shape.dims[i] {
             if shape.dims[i] != 1 {
                 panic!(
-                    "Invalid broadcast shapes: Next grad shape {:?}, Previous grad shape {:?}",
-                    shape.dims, shape_grad.dims
+                    "Invalid broadcast shapes: Next grad shape {:?}, Previous grad shape {:?}. {}",
+                    shape.dims, shape_grad.dims, "Expected the shape of the next grad to be 1."
                 );
             }
             grad = B::sum_dim(grad, i);

--- a/burn-autodiff/src/tests/broadcast.rs
+++ b/burn-autodiff/src/tests/broadcast.rs
@@ -1,24 +1,59 @@
 #[burn_tensor_testgen::testgen(ad_broadcast)]
 mod tests {
     use super::*;
-    use burn_tensor::{Distribution, Tensor};
+    use burn_tensor::{Data, Distribution, Int, Shape, Tensor};
 
     #[test]
     fn should_handle_broacast_during_backward() {
-        let x: Tensor<TestADBackend, 2> =
-            Tensor::random([2, 3], Distribution::Standard).require_grad();
-        let label: Tensor<TestADBackend, 2> =
-            Tensor::random([2, 1], Distribution::Standard).require_grad();
+        let x: Tensor<TestADBackend, 2> = Tensor::from_data(
+            Tensor::<TestADBackend, 1, Int>::arange(0..6)
+                .into_data()
+                .convert(),
+        )
+        .reshape([2, 3])
+        .require_grad();
+        let label: Tensor<TestADBackend, 2> = Tensor::from_data(
+            Tensor::<TestADBackend, 1, Int>::arange(0..2)
+                .into_data()
+                .convert(),
+        )
+        .reshape([2, 1])
+        .require_grad();
 
-        let weights: Tensor<TestADBackend, 2> =
-            Tensor::random([3, 1], Distribution::Standard).require_grad();
-        let bias: Tensor<TestADBackend, 2> =
-            Tensor::random([1, 3], Distribution::Standard).require_grad();
+        let weights: Tensor<TestADBackend, 2> = Tensor::from_data(
+            Tensor::<TestADBackend, 1, Int>::arange(0..3)
+                .into_data()
+                .convert(),
+        )
+        .reshape([3, 1])
+        .require_grad();
 
-        let y = x.matmul(weights.clone()).add(bias.clone());
+        let bias: Tensor<TestADBackend, 2> = Tensor::from_data(
+            Tensor::<TestADBackend, 1, Int>::arange(0..3)
+                .into_data()
+                .convert(),
+        )
+        .reshape([1, 3])
+        .require_grad();
+
+        let y = x.clone().matmul(weights.clone()).add(bias.clone());
         let loss = y.clone().sub(label).powf(2.0).sum();
 
-        let _gradients = loss.backward(); // Should not panic
+        let grads = loss.backward();
+
+        let weights_grad = weights.grad(&grads).unwrap();
+        let bias_grad = bias.grad(&grads).unwrap();
+        let x_grad = x.grad(&grads).unwrap();
+
+        assert_eq!(
+            weights_grad.into_data(),
+            Data::new(vec![252., 372., 492.], Shape::new([3, 1]))
+        );
+        assert_eq!(bias_grad.into_data(), Data::from([[36., 40., 44.]]));
+        assert_eq!(
+            x_grad.into_data(),
+            Data::from([[0., 36., 72.], [0., 84., 168.]])
+        );
     }
 
     #[test]

--- a/burn-autodiff/src/tests/broadcast.rs
+++ b/burn-autodiff/src/tests/broadcast.rs
@@ -22,11 +22,11 @@ mod tests {
     }
 
     #[test]
-    fn grad_should_be_same_size_as_tensor() {
+    fn grad_same_shape_as_forward_tensor() {
         let x: Tensor<TestADBackend, 2> =
             Tensor::random([2, 1], Distribution::Standard).require_grad();
         let y: Tensor<TestADBackend, 2> =
-            Tensor::random([1, 3], Distribution::Standard).require_grad();
+            Tensor::random([2, 3], Distribution::Standard).require_grad();
         let z = x.clone().add(y);
 
         let grads = z.backward();

--- a/burn-autodiff/src/tests/broadcast.rs
+++ b/burn-autodiff/src/tests/broadcast.rs
@@ -1,0 +1,37 @@
+#[burn_tensor_testgen::testgen(ad_broadcast)]
+mod tests {
+    use super::*;
+    use burn_tensor::{Distribution, Tensor};
+
+    #[test]
+    fn should_handle_broacast_during_backward() {
+        let x: Tensor<TestADBackend, 2> =
+            Tensor::random([2, 3], Distribution::Standard).require_grad();
+        let label: Tensor<TestADBackend, 2> =
+            Tensor::random([2, 1], Distribution::Standard).require_grad();
+
+        let weights: Tensor<TestADBackend, 2> =
+            Tensor::random([3, 1], Distribution::Standard).require_grad();
+        let bias: Tensor<TestADBackend, 2> =
+            Tensor::random([1, 3], Distribution::Standard).require_grad();
+
+        let y = x.matmul(weights.clone()).add(bias.clone());
+        let loss = y.clone().sub(label).powf(2.0).sum();
+
+        let _gradients = loss.backward(); // Should not panic
+    }
+
+    #[test]
+    fn grad_should_be_same_size_as_tensor() {
+        let x: Tensor<TestADBackend, 2> =
+            Tensor::random([2, 1], Distribution::Standard).require_grad();
+        let y: Tensor<TestADBackend, 2> =
+            Tensor::random([1, 3], Distribution::Standard).require_grad();
+        let z = x.clone().add(y);
+
+        let grads = z.backward();
+        let x_grad = x.grad(&grads).unwrap();
+
+        assert!(x_grad.shape() == x.shape());
+    }
+}

--- a/burn-autodiff/src/tests/mod.rs
+++ b/burn-autodiff/src/tests/mod.rs
@@ -1,6 +1,7 @@
 mod add;
 mod aggregation;
 mod backward;
+mod broadcast;
 mod cat;
 mod complex;
 mod conv1d;
@@ -36,6 +37,9 @@ macro_rules! testgen_all {
     () => {
         type TestADBackend = burn_autodiff::ADBackendDecorator<TestBackend>;
         type TestADTensor<const D: usize, K> = burn_tensor::Tensor<TestADBackend, D, K>;
+
+        // Behavior
+        burn_autodiff::testgen_ad_broadcast!();
 
         // Modules
         burn_autodiff::testgen_ad_conv1d!();


### PR DESCRIPTION
fix #181 

The problem occured for stateless binary operations with broadcasting during the forward pass.