### PR TITLE
Bump version to the next minor to indicate dev

### DIFF
--- a/burn-autodiff/Cargo.toml
+++ b/burn-autodiff/Cargo.toml
@@ -8,16 +8,16 @@ license = "MIT/Apache-2.0"
 name = "burn-autodiff"
 readme = "README.md"
 repository = "https://github.com/burn-rs/burn/tree/main/burn-autodiff"
-version = "0.7.0"
+version = "0.8.0"
 
 [features]
 default = ["export_tests"]
 export_tests = ["burn-tensor-testgen"]
 
 [dependencies]
-burn-common = {path = "../burn-common", version = "0.7.0"}
-burn-tensor = {path = "../burn-tensor", version = "0.7.0"}
-burn-tensor-testgen = {path = "../burn-tensor-testgen", version = "0.7.0", optional = true}
+burn-common = {path = "../burn-common", version = "0.8.0" }
+burn-tensor = {path = "../burn-tensor", version = "0.8.0" }
+burn-tensor-testgen = {path = "../burn-tensor-testgen", version = "0.8.0", optional = true}
 
 derive-new = {workspace = true}
 spin = {workspace = true}

--- a/burn-common/Cargo.toml
+++ b/burn-common/Cargo.toml
@@ -8,7 +8,7 @@ keywords = []
 categories = []
 readme = "README.md"
 repository = "https://github.com/burn-rs/burn/tree/main/burn-common"
-version = "0.7.0"
+version = "0.8.0"
 
 [features]
 default = ["std"]

--- a/burn-core/Cargo.toml
+++ b/burn-core/Cargo.toml
@@ -9,7 +9,7 @@ name = "burn-core"
 readme = "README.md"
 repository = "https://github.com/burn-rs/burn/tree/main/burn-core"
 
-version = "0.7.0"
+version = "0.8.0"
 
 [features]
 default = ["std"]
@@ -39,11 +39,11 @@ experimental-named-tensor = ["burn-tensor/experimental-named-tensor"]
 
 # ** Please make sure all dependencies support no_std when std is disabled **
 
-burn-autodiff = {path = "../burn-autodiff", version = "0.7.0", optional = true, features = ["export_tests"]}
-burn-common = {path = "../burn-common", version = "0.7.0", default-features = false}
-burn-dataset = {path = "../burn-dataset", version = "0.7.0", default-features = false, optional = true}
-burn-derive = {path = "../burn-derive", version = "0.7.0"}
-burn-tensor = {path = "../burn-tensor", version = "0.7.0", default-features = false}
+burn-autodiff = {path = "../burn-autodiff", version = "0.8.0", optional = true, features = ["export_tests"]}
+burn-common = {path = "../burn-common", version = "0.8.0", default-features = false}
+burn-dataset = {path = "../burn-dataset", version = "0.8.0", default-features = false, optional = true}
+burn-derive = {path = "../burn-derive", version = "0.8.0" }
+burn-tensor = {path = "../burn-tensor", version = "0.8.0", default-features = false}
 
 derive-new = {workspace = true}
 libm = {workspace = true}
@@ -65,9 +65,9 @@ bincode = {workspace = true}
 half = {workspace = true}
 
 [dev-dependencies]
-burn-dataset = {path = "../burn-dataset", version = "0.7.0", features = [
+burn-dataset = {path = "../burn-dataset", version = "0.8.0", features = [
   "fake",
 ]}
 
-burn-ndarray = {path = "../burn-ndarray", version = "0.7.0", default-features = false}
-burn-tch = {path = "../burn-tch", version = "0.7.0"}
+burn-ndarray = {path = "../burn-ndarray", version = "0.8.0", default-features = false}
+burn-tch = {path = "../burn-tch", version = "0.8.0" }

--- a/burn-dataset/Cargo.toml
+++ b/burn-dataset/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 name = "burn-dataset"
 readme = "README.md"
 repository = "https://github.com/burn-rs/burn/tree/main/burn-dataset"
-version = "0.7.0"
+version = "0.8.0"
 
 [features]
 default = ["fake"]

--- a/burn-derive/Cargo.toml
+++ b/burn-derive/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT/Apache-2.0"
 name = "burn-derive"
 readme = "README.md"
 repository = "https://github.com/burn-rs/burn/tree/main/burn-derive"
-version = "0.7.0"
+version = "0.8.0"
 
 [lib]
 proc-macro = true

--- a/burn-import/Cargo.toml
+++ b/burn-import/Cargo.toml
@@ -11,15 +11,15 @@ Burn import crate.
 readme = "README.md"
 repository = "https://github.com/burn-rs/burn/tree/main/burn-import"
 
-version = "0.7.0"
+version = "0.8.0"
 
 [features]
 default = ["onnx"]
 onnx = []
 
 [dependencies]
-burn = {path = "../burn", version = "0.7.0"}
-burn-ndarray = {path = "../burn-ndarray", version = "0.7.0"}
+burn = {path = "../burn", version = "0.8.0" }
+burn-ndarray = {path = "../burn-ndarray", version = "0.8.0" }
 
 bytemuck = {workspace = true}
 derive-new = {workspace = true}

--- a/burn-ndarray/Cargo.toml
+++ b/burn-ndarray/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT/Apache-2.0"
 name = "burn-ndarray"
 readme = "README.md"
 repository = "https://github.com/burn-rs/burn/tree/main/burn-ndarray"
-version = "0.7.0"
+version = "0.8.0"
 
 [features]
 default = ["std"]
@@ -38,9 +38,9 @@ blas-openblas-system = [
 
 # ** Please make sure all dependencies support no_std when std is disabled **
 
-burn-autodiff = {path = "../burn-autodiff", version = "0.7.0", features = ["export_tests"], optional = true}
-burn-common = {path = "../burn-common", version = "0.7.0", default-features = false}
-burn-tensor = {path = "../burn-tensor", version = "0.7.0", default-features = false, features = ["export_tests"]}
+burn-autodiff = {path = "../burn-autodiff", version = "0.8.0", features = ["export_tests"], optional = true}
+burn-common = {path = "../burn-common", version = "0.8.0", default-features = false}
+burn-tensor = {path = "../burn-tensor", version = "0.8.0", default-features = false, features = ["export_tests"]}
 
 
 matrixmultiply = {version = "0.3.6", default-features = false}

--- a/burn-no-std-tests/Cargo.toml
+++ b/burn-no-std-tests/Cargo.toml
@@ -9,13 +9,13 @@ name = "burn-no-std-tests"
 readme = "README.md"
 repository = "https://github.com/burn-rs/burn/tree/main/burn-no-std-tests"
 
-version = "0.7.0"
+version = "0.8.0"
 
 [dependencies]
 
 # ** Please make sure all dependencies support no_std **
 
-burn = {path = "../burn", version = "0.7.0", default-features = false}
-burn-ndarray = {path = "../burn-ndarray", version = "0.7.0", default-features = false}
+burn = {path = "../burn", version = "0.8.0", default-features = false}
+burn-ndarray = {path = "../burn-ndarray", version = "0.8.0", default-features = false}
 
 serde = {workspace = true}

--- a/burn-tch/Cargo.toml
+++ b/burn-tch/Cargo.toml
@@ -8,13 +8,13 @@ license = "MIT/Apache-2.0"
 name = "burn-tch"
 readme = "README.md"
 repository = "https://github.com/burn-rs/burn/tree/main/burn-tch"
-version = "0.7.0"
+version = "0.8.0"
 
 [features]
 doc = ["tch/doc-only"]
 
 [dependencies]
-burn-tensor = {path = "../burn-tensor", version = "0.7.0"}
+burn-tensor = {path = "../burn-tensor", version = "0.8.0" }
 libc = "0.2.0"
 
 half = {workspace = true, features = ["std"]}
@@ -29,9 +29,9 @@ tch = {version = "0.11.0"}
 tch = {version = "0.11.0", default-features = false} # Disables torch downloading
 
 [dev-dependencies]
-burn-autodiff = {path = "../burn-autodiff", version = "0.7.0", default-features = false, features = [
+burn-autodiff = {path = "../burn-autodiff", version = "0.8.0", default-features = false, features = [
   "export_tests",
 ]}
-burn-tensor = {path = "../burn-tensor", version = "0.7.0", default-features = false, features = [
+burn-tensor = {path = "../burn-tensor", version = "0.8.0", default-features = false, features = [
   "export_tests",
 ]}

--- a/burn-tensor-testgen/Cargo.toml
+++ b/burn-tensor-testgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "burn-tensor-testgen"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["nathanielsimard <nathaniel.simard.42@gmail.com>"]
 description = "Burn tensor test gen crate."
 repository = "https://github.com/burn-rs/burn/tree/main/burn-tensor-testgen"

--- a/burn-tensor/Cargo.toml
+++ b/burn-tensor/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT/Apache-2.0"
 name = "burn-tensor"
 readme = "README.md"
 repository = "https://github.com/burn-rs/burn/tree/main/burn-tensor"
-version = "0.7.0"
+version = "0.8.0"
 
 [features]
 default = ["std"]
@@ -24,7 +24,7 @@ std = [
 ]
 
 [dependencies]
-burn-tensor-testgen = {path = "../burn-tensor-testgen", version = "0.7.0", optional = true}
+burn-tensor-testgen = {path = "../burn-tensor-testgen", version = "0.8.0", optional = true}
 
 derive-new = {workspace = true}
 half = {workspace = true}

--- a/burn-train/Cargo.toml
+++ b/burn-train/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "burn-train"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["nathanielsimard <nathaniel.simard.42@gmail.com>"]
 description = "Training crate for burn"
 repository = "https://github.com/burn-rs/burn/tree/main/burn-train"
@@ -12,7 +12,7 @@ license = "MIT/Apache-2.0"
 edition = "2021"
 
 [dependencies]
-burn-core = { path = "../burn-core", version = "0.7.0" }
+burn-core = { path = "../burn-core", version = "0.8.0" }
 
 # Console
 indicatif = "0.17.2"
@@ -30,4 +30,4 @@ derive-new = { workspace = true }
 serde = { workspace = true, features = ["std", "derive"] }
 
 [dev-dependencies]
-burn-ndarray = { path ="../burn-ndarray", version = "0.7.0" }
+burn-ndarray = { path ="../burn-ndarray", version = "0.8.0" }

--- a/burn/Cargo.toml
+++ b/burn/Cargo.toml
@@ -9,7 +9,7 @@ name = "burn"
 readme = "README.md"
 repository = "https://github.com/burn-rs/burn"
 
-version = "0.7.0"
+version = "0.8.0"
 
 [features]
 default = ["std", "train"]
@@ -23,5 +23,5 @@ train = ["std", "burn-train"] # Training requires std
 
 # ** Please make sure all dependencies support no_std when std is disabled **
 
-burn-core = {path = "../burn-core", version = "0.7.0", default-features = false}
-burn-train = {path = "../burn-train", version = "0.7.0", optional = true}
+burn-core = {path = "../burn-core", version = "0.8.0", default-features = false}
+burn-train = {path = "../burn-train", version = "0.8.0", optional = true}

--- a/examples/mnist-inference-web/Cargo.toml
+++ b/examples/mnist-inference-web/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2021"
 license = "MIT/Apache-2.0"
 name = "mnist-inference-web"
 publish = false
-version = "0.6.0"
+version = "0.8.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/mnist/Cargo.toml
+++ b/examples/mnist/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mnist"
-version = "0.6.0"
+version = "0.8.0"
 authors = ["nathanielsimard <nathaniel.simard.42@gmail.com>"]
 license = "MIT/Apache-2.0"
 edition = "2021"

--- a/examples/named-tensor/Cargo.toml
+++ b/examples/named-tensor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "named-tensor"
-version = "0.6.0"
+version = "0.8.0"
 authors = ["nathanielsimard <nathaniel.simard.42@gmail.com>"]
 license = "MIT/Apache-2.0"
 edition = "2021"

--- a/examples/onnx-inference/Cargo.toml
+++ b/examples/onnx-inference/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2021"
 license = "MIT/Apache-2.0"
 name = "onnx-inference"
 publish = false
-version = "0.6.0"
+version = "0.8.0"
 
 [features]
 default = []

--- a/examples/text-classification/Cargo.toml
+++ b/examples/text-classification/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2021"
 license = "MIT/Apache-2.0"
 name = "text-classification"
 publish = false
-version = "0.6.0"
+version = "0.8.0"
 
 [features]
 default = []

--- a/examples/text-generation/Cargo.toml
+++ b/examples/text-generation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text-generation"
-version = "0.6.0"
+version = "0.8.0"
 authors = ["nathanielsimard <nathaniel.simard.42@gmail.com>"]
 license = "MIT/Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
Fixes: #281

I used [cargo-edit tool](https://github.com/killercup/cargo-edit#cargo-set-version) to bump up all versions: 

```
cargo set-version --bump minor
```