### PR TITLE
feat: improve module recorder deserialization

### DIFF
--- a/burn-core/src/module/param/constant.rs
+++ b/burn-core/src/module/param/constant.rs
@@ -1,9 +1,45 @@
-use crate as burn;
+use crate::{self as burn, record::Record};
+use burn::record::PrecisionSettings;
+
+/// Record used for constant type implementing the [module](crate::module::Module) trait.
+#[derive(Debug, Clone, new)]
+pub struct ConstantRecord;
+
+impl serde::Serialize for ConstantRecord {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // nothing to serialize
+        S::serialize_none(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ConstantRecord {
+    fn deserialize<D>(_deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(ConstantRecord::new())
+    }
+}
+
+impl Record for ConstantRecord {
+    type Item<S: PrecisionSettings> = ConstantRecord;
+
+    fn into_item<S: PrecisionSettings>(self) -> Self::Item<S> {
+        self
+    }
+
+    fn from_item<S: PrecisionSettings>(item: Self::Item<S>) -> Self {
+        item
+    }
+}
 
 #[macro_export]
 macro_rules! constant {
     (module) => {
-        type Record = ();
+        type Record = burn::module::ConstantRecord;
 
         fn visit<V: burn::module::ModuleVisitor<B>>(&self, _visitor: &mut V) {
             // Nothing to do
@@ -17,7 +53,9 @@ macro_rules! constant {
             self
         }
 
-        fn into_record(self) -> Self::Record {}
+        fn into_record(self) -> Self::Record {
+            burn::module::ConstantRecord::new()
+        }
     };
 
     (ad_module, $type:ty) => {

--- a/burn-core/src/module/param/mod.rs
+++ b/burn-core/src/module/param/mod.rs
@@ -7,6 +7,7 @@ mod tensor;
 mod visitor;
 
 pub use base::*;
+pub use constant::*;
 pub use id::*;
 pub use running::*;
 pub use tensor::*;

--- a/burn-core/tests/record_resilience.rs
+++ b/burn-core/tests/record_resilience.rs
@@ -28,6 +28,13 @@ mod tests {
     }
 
     #[derive(Module, Debug)]
+    pub struct ModelNewConstantField<B: Backend> {
+        linear1: nn::Linear<B>,
+        linear2: nn::Linear<B>,
+        new_field: usize,
+    }
+
+    #[derive(Module, Debug)]
     pub struct ModelNewFieldOrders<B: Backend> {
         linear2: nn::Linear<B>,
         linear1: nn::Linear<B>,
@@ -36,6 +43,33 @@ mod tests {
     #[test]
     fn deserialize_with_new_optional_field_works_with_default_file_recorder() {
         deserialize_with_new_optional_field(
+            "default",
+            DefaultFileRecorder::<FullPrecisionSettings>::new(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn deserialize_with_removed_optional_field_works_with_default_file_recorder() {
+        deserialize_with_removed_optional_field(
+            "default",
+            DefaultFileRecorder::<FullPrecisionSettings>::new(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn deserialize_with_new_constant_field_works_with_default_file_recorder() {
+        deserialize_with_new_constant_field(
+            "default",
+            DefaultFileRecorder::<FullPrecisionSettings>::new(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn deserialize_with_removed_constant_field_works_with_default_file_recorder() {
+        deserialize_with_removed_constant_field(
             "default",
             DefaultFileRecorder::<FullPrecisionSettings>::new(),
         )
@@ -60,6 +94,33 @@ mod tests {
     }
 
     #[test]
+    fn deserialize_with_removed_optional_field_works_with_pretty_json() {
+        deserialize_with_removed_optional_field(
+            "pretty-json",
+            PrettyJsonFileRecorder::<FullPrecisionSettings>::new(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn deserialize_with_new_constant_field_works_with_pretty_json() {
+        deserialize_with_new_constant_field(
+            "pretty-json",
+            PrettyJsonFileRecorder::<FullPrecisionSettings>::new(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn deserialize_with_removed_constant_field_works_with_pretty_json() {
+        deserialize_with_removed_constant_field(
+            "pretty-json",
+            PrettyJsonFileRecorder::<FullPrecisionSettings>::new(),
+        )
+        .unwrap();
+    }
+
+    #[test]
     fn deserialize_with_new_field_order_works_with_pretty_json() {
         deserialize_with_new_field_order(
             "pretty-json",
@@ -73,6 +134,30 @@ mod tests {
     fn deserialize_with_new_optional_field_doesnt_works_with_bin_file_recorder() {
         deserialize_with_new_optional_field("bin", BinFileRecorder::<FullPrecisionSettings>::new())
             .unwrap();
+    }
+
+    #[test]
+    fn deserialize_with_removed_optional_field_works_with_bin_file_recorder() {
+        deserialize_with_removed_optional_field(
+            "bin",
+            BinFileRecorder::<FullPrecisionSettings>::new(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn deserialize_with_new_constant_field_works_with_bin_file_recorder() {
+        deserialize_with_new_constant_field("bin", BinFileRecorder::<FullPrecisionSettings>::new())
+            .unwrap();
+    }
+
+    #[test]
+    fn deserialize_with_removed_constant_field_works_with_bin_file_recorder() {
+        deserialize_with_removed_constant_field(
+            "bin",
+            BinFileRecorder::<FullPrecisionSettings>::new(),
+        )
+        .unwrap();
     }
 
     #[test]
@@ -95,6 +180,76 @@ mod tests {
             .record(model.into_record(), file_path.clone())
             .unwrap();
         let result = recorder.load::<ModelNewOptionalFieldRecord<TestBackend>>(file_path.clone());
+        std::fs::remove_file(file_path).ok();
+
+        result?;
+        Ok(())
+    }
+
+    fn deserialize_with_removed_optional_field<R>(
+        name: &str,
+        recorder: R,
+    ) -> Result<(), RecorderError>
+    where
+        R: FileRecorder,
+    {
+        let file_path: PathBuf =
+            format!("/tmp/deserialize_with_removed_optional_field-{name}").into();
+        let model = ModelNewOptionalField {
+            linear1: nn::LinearConfig::new(20, 20).init::<TestBackend>(),
+            linear2: nn::LinearConfig::new(20, 20).init::<TestBackend>(),
+            new_field: None,
+        };
+
+        recorder
+            .record(model.into_record(), file_path.clone())
+            .unwrap();
+        let result = recorder.load::<ModelRecord<TestBackend>>(file_path.clone());
+        std::fs::remove_file(file_path).ok();
+
+        result?;
+        Ok(())
+    }
+
+    fn deserialize_with_new_constant_field<R>(name: &str, recorder: R) -> Result<(), RecorderError>
+    where
+        R: FileRecorder,
+    {
+        let file_path: PathBuf = format!("/tmp/deserialize_with_new_constant_field-{name}").into();
+        let model = Model {
+            linear1: nn::LinearConfig::new(20, 20).init::<TestBackend>(),
+            linear2: nn::LinearConfig::new(20, 20).init::<TestBackend>(),
+        };
+
+        recorder
+            .record(model.into_record(), file_path.clone())
+            .unwrap();
+        let result = recorder.load::<ModelNewConstantFieldRecord<TestBackend>>(file_path.clone());
+        std::fs::remove_file(file_path).ok();
+
+        result?;
+        Ok(())
+    }
+
+    fn deserialize_with_removed_constant_field<R>(
+        name: &str,
+        recorder: R,
+    ) -> Result<(), RecorderError>
+    where
+        R: FileRecorder,
+    {
+        let file_path: PathBuf =
+            format!("/tmp/deserialize_with_removed_constant_field-{name}").into();
+        let model = ModelNewConstantField {
+            linear1: nn::LinearConfig::new(20, 20).init::<TestBackend>(),
+            linear2: nn::LinearConfig::new(20, 20).init::<TestBackend>(),
+            new_field: 0,
+        };
+
+        recorder
+            .record(model.into_record(), file_path.clone())
+            .unwrap();
+        let result = recorder.load::<ModelRecord<TestBackend>>(file_path.clone());
         std::fs::remove_file(file_path).ok();
 
         result?;


### PR DESCRIPTION
Added `ConstantRecord` so that deserialization can be made even when the `constant` names are not present in the file.