### PR TITLE
feat: burn import logging

### DIFF
--- a/burn-import/Cargo.toml
+++ b/burn-import/Cargo.toml
@@ -22,6 +22,8 @@ burn = {path = "../burn", version = "0.8.0" }
 burn-ndarray = {path = "../burn-ndarray", version = "0.8.0" }
 burn-common = {path = "../burn-common", version = "0.8.0" }
 
+log = {workspace = true}
+log4rs = { workspace = true }
 bytemuck = {workspace = true}
 derive-new = {workspace = true}
 half = {workspace = true}

--- a/burn-import/src/burn/graph.rs
+++ b/burn-import/src/burn/graph.rs
@@ -30,7 +30,9 @@ impl<PS: PrecisionSettings> BurnGraph<PS> {
     ///
     /// The node must be registered in the same order they will be executed in the forward pass.
     pub fn register<N: NodeCodegen<PS> + 'static>(&mut self, node: N) {
-        self.nodes.push(node.into_node());
+        let node = node.into_node();
+        log::debug!("Registering node => '{}'", node.name());
+        self.nodes.push(node);
     }
 
     /// Generate a function `Model::new()` without any argument when `gen_new_fn` is `true`.

--- a/burn-import/src/burn/node/base.rs
+++ b/burn-import/src/burn/node/base.rs
@@ -102,6 +102,20 @@ impl<PS: PrecisionSettings> Serialize for Node<PS> {
     }
 }
 
+impl<PS: PrecisionSettings> Node<PS> {
+    pub fn name(&self) -> &str {
+        match self {
+            Node::Matmul(_) => "matmul",
+            Node::Conv2d(_) => "conv2d",
+            Node::Linear(_) => "linear",
+            Node::BatchNorm(_) => "batch_norm",
+            Node::ReLU(_) => "relu",
+            Node::Flatten(_) => "flatten",
+            Node::LogSoftmax(_) => "log_softmax",
+        }
+    }
+}
+
 impl<PS: PrecisionSettings> NodeCodegen<PS> for Node<PS> {
     fn output_types(&self) -> Vec<Type> {
         match_all!(self, NodeCodegen::<PS>::output_types)

--- a/burn-import/src/lib.rs
+++ b/burn-import/src/lib.rs
@@ -11,4 +11,5 @@ pub mod onnx;
 pub mod burn;
 
 mod formater;
+mod logger;
 pub use formater::*;

--- a/burn-import/src/logger.rs
+++ b/burn-import/src/logger.rs
@@ -1,0 +1,30 @@
+use log::{LevelFilter, SetLoggerError};
+use log4rs::{
+    append::console::ConsoleAppender,
+    config::{Appender, Root},
+    Config,
+};
+
+pub fn init_log() -> Result<(), SetLoggerError> {
+    let stdout = ConsoleAppender::builder().build();
+    let appender = Appender::builder().build("stdout", Box::new(stdout));
+
+    log4rs::init_config(
+        Config::builder()
+            .appender(appender)
+            .build(Root::builder().appender("stdout").build(LevelFilter::Debug))
+            .unwrap(),
+    )?;
+    update_panic_hook();
+
+    Ok(())
+}
+
+fn update_panic_hook() {
+    let hook = std::panic::take_hook();
+
+    std::panic::set_hook(Box::new(move |info| {
+        log::error!("PANIC => {}", info.to_string());
+        hook(info);
+    }));
+}

--- a/burn-import/src/logger.rs
+++ b/burn-import/src/logger.rs
@@ -2,11 +2,14 @@ use log::{LevelFilter, SetLoggerError};
 use log4rs::{
     append::console::ConsoleAppender,
     config::{Appender, Root},
+    encode::pattern::PatternEncoder,
     Config,
 };
 
 pub fn init_log() -> Result<(), SetLoggerError> {
-    let stdout = ConsoleAppender::builder().build();
+    let stdout = ConsoleAppender::builder()
+        .encoder(Box::new(PatternEncoder::new("[{h({l})} - {f}:{L}] {m}{n}")))
+        .build();
     let appender = Appender::builder().build("stdout", Box::new(stdout));
 
     log4rs::init_config(

--- a/burn-import/src/onnx/from_onnx.rs
+++ b/burn-import/src/onnx/from_onnx.rs
@@ -372,7 +372,8 @@ pub fn convert_node_proto(node: &NodeProto) -> Node {
         .collect();
     let attrs = convert_vec_attrs_proto(node.attribute.clone());
 
-    let node_type = NodeType::from_str(node.op_type.as_str()).unwrap();
+    log::debug!("Found ONNX node type => {}", node.op_type.as_str());
+    let node_type = NodeType::from_str(node.op_type.as_str()).expect("Unknown node type");
 
     let is_stateful = STATEFUL_NODE_TYPES.contains(&node_type);
 
@@ -399,7 +400,7 @@ fn remap_node_type(node: &mut Node) {
                 node.node_type = match ints.len() {
                     1 => NodeType::Conv1d,
                     2 => NodeType::Conv2d,
-                    _ => todo!(),
+                    _ => panic!("Only conv 1d and 2d are supported"),
                 };
             } else {
                 panic!("kernel_shape is not an int64s");

--- a/burn-import/src/onnx/to_burn.rs
+++ b/burn-import/src/onnx/to_burn.rs
@@ -19,6 +19,7 @@ use crate::{
         TensorType,
     },
     format_tokens,
+    logger::init_log,
     onnx::{
         ir::{Node, NodeType},
         op_configuration::{
@@ -43,6 +44,7 @@ pub struct ModelGen {
 
 impl ModelGen {
     pub fn new() -> Self {
+        init_log().ok(); // Error when init multiple times are ignored.
         Self::default()
     }
 


### PR DESCRIPTION
Add basic logging in burn-import making it easier to debug:

```
Caused by:
  process didn't exit successfully: `/home/nathaniel/Projects/burn/target/debug/build/onnx-inference-58acc7fb67488443/build-script-build` (exit status: 101)
  --- stdout
  [DEBUG - burn-import/src/onnx/from_onnx.rs:375] Found ONNX node type => Conv
  [DEBUG - burn-import/src/onnx/from_onnx.rs:375] Found ONNX node type => Relu
  [DEBUG - burn-import/src/onnx/from_onnx.rs:375] Found ONNX node type => Conv
  [DEBUG - burn-import/src/onnx/from_onnx.rs:375] Found ONNX node type => Relu
  [DEBUG - burn-import/src/onnx/from_onnx.rs:375] Found ONNX node type => Conv
  [DEBUG - burn-import/src/onnx/from_onnx.rs:375] Found ONNX node type => Relu
  [DEBUG - burn-import/src/onnx/from_onnx.rs:375] Found ONNX node type => BatchNormalization
  [DEBUG - burn-import/src/onnx/from_onnx.rs:375] Found ONNX node type => Flatten
  [DEBUG - burn-import/src/onnx/from_onnx.rs:375] Found ONNX node type => Gemm
  [DEBUG - burn-import/src/onnx/from_onnx.rs:375] Found ONNX node type => Relu
  [DEBUG - burn-import/src/onnx/from_onnx.rs:375] Found ONNX node type => Gemm
  [DEBUG - burn-import/src/onnx/from_onnx.rs:375] Found ONNX node type => BatchNormalization
  [DEBUG - burn-import/src/onnx/from_onnx.rs:375] Found ONNX node type => LogSoftmax
  [DEBUG - burn-import/src/burn/graph.rs:34] Registering node => 'conv2d'
  [DEBUG - burn-import/src/burn/graph.rs:34] Registering node => 'relu'
  [DEBUG - burn-import/src/burn/graph.rs:34] Registering node => 'conv2d'
  [DEBUG - burn-import/src/burn/graph.rs:34] Registering node => 'relu'
  [DEBUG - burn-import/src/burn/graph.rs:34] Registering node => 'conv2d'
  [DEBUG - burn-import/src/burn/graph.rs:34] Registering node => 'relu'
  [ERROR - burn-import/src/logger.rs:32] PANIC => panicked at 'Fake error while converting batch norm node', burn-import/src/burn/node/batch_norm.rs:158:9

  --- stderr
  thread 'main' panicked at 'Fake error while converting batch norm node', burn-import/src/burn/node/batch_norm.rs:158:9
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```