### PR TITLE
[WIP] Use portable atomics to build for thumbv6m-none-eabi target

### DIFF
--- a/burn-autodiff/Cargo.toml
+++ b/burn-autodiff/Cargo.toml
@@ -20,4 +20,3 @@ burn-tensor = {path = "../burn-tensor", version = "0.8.0" }
 burn-tensor-testgen = {path = "../burn-tensor-testgen", version = "0.8.0", optional = true}
 
 derive-new = {workspace = true}
-spin = {workspace = true}

--- a/burn-common/Cargo.toml
+++ b/burn-common/Cargo.toml
@@ -23,7 +23,12 @@ std = [
 
 const-random = {workspace = true}
 rand = {workspace = true}
-spin = {workspace = true}# using in place of use std::sync::Mutex;          
+spin = {workspace = true, features = ["mutex", "spin_mutex", "portable_atomic"]}
+portable-atomic = {version = "1.3.3", features = ["critical-section"]}
+portable-atomic-util = {version = "0.1.3", features = ["alloc"]}
+
+
+
 uuid = {workspace = true}
 
 [dev-dependencies]

--- a/burn-common/src/id.rs
+++ b/burn-common/src/id.rs
@@ -1,12 +1,26 @@
 use alloc::string::{String, ToString};
 
-use crate::rand::{get_seeded_rng, Rng, SEED};
+use rand::Rng;
+
+#[cfg(not(feature = "std"))]
+use crate::rand::{get_seeded_rng, SEED};
 
 use uuid::{Builder, Bytes};
 
 pub struct IdGenerator {}
 
 impl IdGenerator {
+    #[cfg(feature = "std")]
+    #[inline(always)]
+    pub fn generate() -> String {
+        let mut rng = rand::thread_rng();
+        let random_bytes: Bytes = rng.gen();
+        let uuid = Builder::from_random_bytes(random_bytes).into_uuid();
+        uuid.as_hyphenated().to_string()
+    }
+
+    #[cfg(not(feature = "std"))]
+    #[inline(always)]
     pub fn generate() -> String {
         let mut seed = SEED.lock().unwrap();
         let mut rng = if let Some(rng_seeded) = seed.as_ref() {
@@ -19,7 +33,6 @@ impl IdGenerator {
         *seed = Some(rng);
 
         let uuid = Builder::from_random_bytes(random_bytes).into_uuid();
-
         uuid.as_hyphenated().to_string()
     }
 }

--- a/burn-common/src/lib.rs
+++ b/burn-common/src/lib.rs
@@ -1,7 +1,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod id;
+
+#[cfg(not(feature = "std"))]
 pub mod rand;
+
 pub mod stub;
 
 extern crate alloc;

--- a/burn-common/src/rand.rs
+++ b/burn-common/src/rand.rs
@@ -1,21 +1,9 @@
-pub use rand::{rngs::StdRng, Rng, SeedableRng};
-
-#[cfg(feature = "std")]
-use std::sync::Mutex;
-
-#[cfg(not(feature = "std"))]
 use crate::stub::Mutex;
 
-#[cfg(not(feature = "std"))]
+use rand::{rngs::StdRng, SeedableRng};
+
 use const_random::const_random;
 
-#[cfg(feature = "std")]
-#[inline(always)]
-pub fn get_seeded_rng() -> StdRng {
-    StdRng::from_entropy()
-}
-
-#[cfg(not(feature = "std"))]
 #[inline(always)]
 pub fn get_seeded_rng() -> StdRng {
     const GENERATED_SEED: u64 = const_random!(u64);

--- a/burn-core/Cargo.toml
+++ b/burn-core/Cargo.toml
@@ -50,7 +50,12 @@ libm = {workspace = true}
 log = {workspace = true, optional = true}
 rand = {workspace = true, features = ["std_rng"]}# Default enables std  
 # Using in place of use std::sync::Mutex when std is disabled
-spin = {workspace = true, features = ["mutex", "spin_mutex"]}#
+spin = {workspace = true, features = ["mutex", "spin_mutex", "portable_atomic"]}#
+portable-atomic = {version = "1.3.3", features = ["critical-section"]}
+portable-atomic-util = {version = "0.1.3", features = ["alloc"]}
+
+# [target.thumbv6m-none-eabi.dependencies]
+# atomic-polyfill = { version = "1.0.1", optional = true }
 
 # The same implementation of HashMap in std but with no_std support (only alloc crate is needed)
 hashbrown = {workspace = true, features = ["serde"]}# no_std compatible

--- a/burn-core/build.rs
+++ b/burn-core/build.rs
@@ -1,0 +1,14 @@
+use std::{env, error::Error};
+
+/// This build script is used to detect the target architecture and set the
+/// correct cfg flag.
+fn main() -> Result<(), Box<dyn Error>> {
+    let target = env::var("TARGET")?;
+
+    // Set the correct cfg flag depending on the target architecture.
+    // This is used to enable the portable atomic implementation.
+    if target.starts_with("thumbv6m-") {
+        println!("cargo:rustc-cfg=use_portable_atomics");
+    }
+    Ok(())
+}

--- a/burn-core/src/module/param/running.rs
+++ b/burn-core/src/module/param/running.rs
@@ -1,4 +1,8 @@
+#[cfg(not(use_portable_atomics))]
 use alloc::sync::Arc;
+
+#[cfg(use_portable_atomics)]
+use portable_atomic_util::Arc;
 
 use super::ParamId;
 use crate::module::{ADModule, Module, ModuleMapper, ModuleVisitor, Param};

--- a/burn-ndarray/Cargo.toml
+++ b/burn-ndarray/Cargo.toml
@@ -54,4 +54,11 @@ ndarray = {workspace = true}
 num-traits = {workspace = true}
 openblas-src = {version = "0.10.8", optional = true}
 rand = {workspace = true}
-spin = {workspace = true}# using in place of use std::sync::Mutex;
+
+portable-atomic = {version = "1.3.3", features = ["critical-section"]}
+portable-atomic-util = {version = "0.1.3", features = ["alloc"]}
+
+[target.thumbv6m-none-eabi.dependencies]
+atomic-polyfill = { version = "1.0.1"}
+
+# spin = {workspace = true}# using in place of use std::sync::Mutex;

--- a/burn-ndarray/src/backend.rs
+++ b/burn-ndarray/src/backend.rs
@@ -8,12 +8,10 @@ use burn_tensor::backend::Backend;
 
 use rand::{rngs::StdRng, SeedableRng};
 
-#[cfg(feature = "std")]
-use std::sync::Mutex;
-
 #[cfg(not(feature = "std"))]
 use burn_common::stub::Mutex;
 
+#[cfg(not(feature = "std"))]
 pub(crate) static SEED: Mutex<Option<StdRng>> = Mutex::new(None);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/burn-ndarray/src/ops/tensor.rs
+++ b/burn-ndarray/src/ops/tensor.rs
@@ -5,8 +5,8 @@ use core::ops::Range;
 // Current crate
 use super::{matmul::matmul, NdArrayMathOps, NdArrayOps};
 use crate::element::FloatNdArrayElement;
+use crate::NdArrayDevice;
 use crate::{tensor::NdArrayTensor, NdArrayBackend};
-use crate::{NdArrayDevice, SEED};
 
 // Workspace crates
 use burn_common::rand::get_seeded_rng;
@@ -19,11 +19,15 @@ use libm::{cos, erf, sin, tanh};
 #[cfg(not(feature = "std"))]
 use num_traits::Float;
 
+#[cfg(not(feature = "std"))]
+use crate::SEED;
+
 impl<E: FloatNdArrayElement> TensorOps<NdArrayBackend<E>> for NdArrayBackend<E> {
     fn from_data<const D: usize>(data: Data<E, D>, _device: &NdArrayDevice) -> NdArrayTensor<E, D> {
         NdArrayTensor::from_data(data)
     }
 
+    #[cfg(not(feature = "std"))]
     fn random<const D: usize>(
         shape: Shape<D>,
         distribution: Distribution<E>,
@@ -37,6 +41,17 @@ impl<E: FloatNdArrayElement> TensorOps<NdArrayBackend<E>> for NdArrayBackend<E> 
         };
         let tensor = Self::from_data(Data::random(shape, distribution, &mut rng), device);
         *seed = Some(rng);
+        tensor
+    }
+
+    #[cfg(feature = "std")]
+    fn random<const D: usize>(
+        shape: Shape<D>,
+        distribution: Distribution<E>,
+        device: &NdArrayDevice,
+    ) -> NdArrayTensor<E, D> {
+        let mut rng = rand::thread_rng();
+        let tensor = Self::from_data(Data::random(shape, distribution, &mut rng), device);
         tensor
     }
 


### PR DESCRIPTION
Made the bulk of necessary changes to build for  thumbv6m-none-eabi but blocked because Ndarray's acr-array uses sync::arc. core::sync::acr can be replaced by `portable_atomic_util::Arc` but requires changes in the upstream NDarray lib. 

This is the current build error: 


```
[burn-ndarray]$ cargo b --no-default-features --target thumbv6m-none-eabi
   Compiling burn-ndarray v0.8.0 (/Users/dilshod/Projects/burn/burn-ndarray)
   Compiling ndarray v0.15.6
error[E0432]: unresolved import `alloc::sync`
   --> /Users/dilshod/.cargo/registry/src/github.com-1ecc6299db9ec823/ndarray-0.15.6/src/lib.rs:129:12
    |
129 | use alloc::sync::Arc;
    |            ^^^^ could not find `sync` in `alloc`

error[E0432]: unresolved import `alloc::sync`
  --> /Users/dilshod/.cargo/registry/src/github.com-1ecc6299db9ec823/ndarray-0.15.6/src/data_traits.rs:16:12
   |
16 | use alloc::sync::Arc;
   |            ^^^^ could not find `sync` in `alloc`

For more information about this error, try `rustc --explain E0432`.
error: could not compile `ndarray` due to 2 previous errors
[burn-ndarray]$ cargo b --no-default-features --target thumbv6m-none-eabi
```

We will have to work with upstream lib to make it work. We need to submit a PR in NDArray crate.