### PR TITLE
Enhance SqliteDatasetWriter to remove tmp on SIGTERM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ dashmap = "5.4.0"
 dirs = "5.0.1"
 fake = "2.6.1"
 flate2 = "1.0.26"
+gix-tempfile = {version = "5.0.3", features = ["signals"]}
 hashbrown = "0.13.2"
 indicatif = "0.17.3"
 libm = "0.2.7"

--- a/burn-dataset/Cargo.toml
+++ b/burn-dataset/Cargo.toml
@@ -29,11 +29,13 @@ csv = {workspace = true}
 derive-new = {workspace = true}
 dirs = {workspace = true}
 fake = {workspace = true, optional = true}
+gix-tempfile = {workspace = true}
 hound = {version = "3.4.0", optional = true}
 image = {version = "0.24.6", features = ["png"]}
 r2d2 = {workspace = true}
 r2d2_sqlite = {workspace = true}
 rand = {workspace = true, features = ["std"]}
+rmp-serde = {workspace = true}
 rusqlite = {workspace = true}
 sanitize-filename = {workspace = true}
 serde = {workspace = true, features = ["std", "derive"]}
@@ -41,9 +43,8 @@ serde_json = {workspace = true, features = ["std"]}
 serde_rusqlite = {workspace = true}
 strum = {workspace = true}
 strum_macros = {workspace = true}
-thiserror = {workspace = true}
-rmp-serde = {workspace = true}
 tempfile = {workspace = true}
+thiserror = {workspace = true}
 
 [dev-dependencies]
 rayon = {workspace = true}


### PR DESCRIPTION
Temporary files were dangling when a process is terminated by SIGINT (ctrl/cmd+c) or SIGTERM. This change used gix-tempfile to wrap a temporary file with a special signal handle to will remove the tmp file when writer is dropped or when program is terminated early.