### PR TITLE
build(Dockerfile): add Dockerfile for burn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM rust:1.70-alpine3.18
+
+RUN apk add --no-cache \
+    # To get source code
+    git \
+    # To get musl header files
+    musl-dev 
+
+RUN rustup toolchain install nightly \
+    && rustup component add clippy rustfmt --toolchain nightly-x86_64-unknown-linux-musl \
+    && rustup default nightly
+
+WORKDIR /workspace
+
+RUN git clone https://github.com/burn-rs/burn.git
+
+RUN apk del git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.70-slim-bullseye
+FROM rust:1.70-slim-bookworm
 
 RUN apt update \
     && apt install -y \
@@ -11,6 +11,8 @@ RUN apt update \
     g++ \
     # Needs for downloading libtorch
     axel \
+    # Needs for decompression
+    unzip \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -23,9 +25,8 @@ ENV LIBTORCH=/opt/libtorch
 ENV LD_LIBRARY_PATH=/opt/libtorch/lib
 
 RUN rustup component add \
-    # Used in `burn-import/src/formater.rs`
-    rustfmt \
-    clippy
+    # Used by formatter in burn-import
+    rustfmt
     
 WORKDIR /workspace
 
@@ -35,3 +36,5 @@ RUN apt autoremove -y \
     git \
     unzip \
     axel
+
+ENTRYPOINT [ "bash" ]


### PR DESCRIPTION
According to https://github.com/burn-rs/burn/issues/175, it's better to have a Dockerfile for our project.

Below is a tutorial, maybe we could merge it into `README.md` or place it in a separate file.

## How to use

To build the image:

```bash
docker build --network host -t burn .
```

To run a container:

```bash
docker run --name burn -it burn sh
```

For developers who use VS Code, one can click on the button in the left corner of the status bar, then choose **Attach to Running Container...** to attach a new window to container `burn` which was just created.

![image](https://github.com/burn-rs/burn/assets/17194719/98e9fc7b-a7e3-46a2-afc1-b9e54d91e8ea)

Now you can develop as usual. To make things easier, you may need [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer) extension.

You can start a new project with `cargo new`, and specify Burn as dependency with absolute/relative path in `Cargo.toml`, just like:

```toml
burn = {  path = "/workspace/burn/burn" }
```

You can also mount your local file system to the container, and below is an example:

```bash
docker run --name burn -v $PWD:/workspace -it burn sh
```

## Known issue

The image has ~1.55 GB in size though it is based on Alpine Linux. For now it has two version of toolchains: `1.70.0-x86_64-unknown-linux-musl` and `nightly-x86_64-unknown-linux-musl`. The former may be used less frequently but was kept in case of `rustup override` for user's project.

## TODO

1. We could provide a **GPU** supported image as well as an [evcxr-jupyter](https://github.com/evcxr/evcxr/blob/main/evcxr_jupyter/README.md) supported image by Docker's [multi-stage builds](https://docs.docker.com/build/building/multi-stage/).
2. Shall we maintain a repository in DockerHub? If so, users can get different version of images by specifying tag and without need of building locally for convenience.