### PR TITLE
ONNX: Add `Bool` element type

### DIFF
--- a/burn-import/src/onnx/from_onnx.rs
+++ b/burn-import/src/onnx/from_onnx.rs
@@ -208,6 +208,10 @@ impl TryFrom<TensorProto> for Tensor {
                     TensorData::Float64(tensor.double_data)
                 },
             ),
+            DataType::BOOL => (ElementType::Bool, {
+                assert!(!tensor.raw_data.is_empty());
+                TensorData::Bool(cast_slice(&tensor.raw_data[..]).to_vec())
+            }),
             // TODO : Add more types
             _ => {
                 return Err(ParseError::VariantNotFound);

--- a/burn-import/src/onnx/from_onnx.rs
+++ b/burn-import/src/onnx/from_onnx.rs
@@ -210,7 +210,7 @@ impl TryFrom<TensorProto> for Tensor {
             ),
             DataType::BOOL => (ElementType::Bool, {
                 assert!(!tensor.raw_data.is_empty());
-                TensorData::Bool(cast_slice(&tensor.raw_data[..]).to_vec())
+                TensorData::Bool(tensor.raw_data.iter().map(|x| *x != 0).collect())
             }),
             // TODO : Add more types
             _ => {

--- a/burn-import/src/onnx/ir.rs
+++ b/burn-import/src/onnx/ir.rs
@@ -67,7 +67,7 @@ pub enum TensorData {
     Int32(Vec<i32>),
     Int64(Vec<i64>),
     String(Vec<String>),
-    Bool(Vec<u8>),
+    Bool(Vec<bool>),
 }
 
 #[derive(Debug, Clone)]

--- a/burn-import/src/onnx/ir.rs
+++ b/burn-import/src/onnx/ir.rs
@@ -48,6 +48,7 @@ pub enum ElementType {
     Int64,
     String,
     Float16,
+    Bool,
 }
 
 #[derive(Debug, Clone)]
@@ -66,6 +67,7 @@ pub enum TensorData {
     Int32(Vec<i32>),
     Int64(Vec<i64>),
     String(Vec<String>),
+    Bool(Vec<u8>),
 }
 
 #[derive(Debug, Clone)]
@@ -351,6 +353,7 @@ impl fmt::Debug for TensorData {
             TensorData::Int32(v) => write!(f, "Int32({})", trunc(v)),
             TensorData::Int64(v) => write!(f, "Int64({})", trunc(v)),
             TensorData::String(v) => write!(f, "String({})", trunc(v)),
+            TensorData::Bool(v) => write!(f, "Bool({})", trunc(v)),
         }
     }
 }

--- a/burn-import/src/onnx/to_burn.rs
+++ b/burn-import/src/onnx/to_burn.rs
@@ -287,6 +287,7 @@ impl Tensor {
             TensorData::Int32(val) => DataSerialize::new(val, self.shape.unwrap()).convert(),
             TensorData::Int64(val) => DataSerialize::new(val, self.shape.unwrap()).convert(),
             TensorData::String(_) => panic!("String tensor unsuported"),
+            TensorData::Bool(val) => DataSerialize::new(val, self.shape.unwrap()).convert(),
         }
     }
 }

--- a/burn-import/src/onnx/to_burn.rs
+++ b/burn-import/src/onnx/to_burn.rs
@@ -286,11 +286,8 @@ impl Tensor {
             TensorData::Float64(val) => DataSerialize::new(val, self.shape.unwrap()).convert(),
             TensorData::Int32(val) => DataSerialize::new(val, self.shape.unwrap()).convert(),
             TensorData::Int64(val) => DataSerialize::new(val, self.shape.unwrap()).convert(),
-            TensorData::String(_) => panic!("String tensor unsuported"),
-            TensorData::Bool(val) => {
-                DataSerialize::new(val.into_iter().map(u8::from).collect(), self.shape.unwrap())
-                    .convert()
-            }
+            TensorData::String(_) => panic!("String tensor unsupported"),
+            TensorData::Bool(_) => panic!("Bool tensor unsupported"),
         }
     }
 }

--- a/burn-import/src/onnx/to_burn.rs
+++ b/burn-import/src/onnx/to_burn.rs
@@ -287,7 +287,10 @@ impl Tensor {
             TensorData::Int32(val) => DataSerialize::new(val, self.shape.unwrap()).convert(),
             TensorData::Int64(val) => DataSerialize::new(val, self.shape.unwrap()).convert(),
             TensorData::String(_) => panic!("String tensor unsuported"),
-            TensorData::Bool(val) => DataSerialize::new(val, self.shape.unwrap()).convert(),
+            TensorData::Bool(val) => {
+                DataSerialize::new(val.into_iter().map(u8::from).collect(), self.shape.unwrap())
+                    .convert()
+            }
         }
     }
 }


### PR DESCRIPTION
### Summary

- While parsing a model (hubert) mentioned at https://github.com/burn-rs/burn/issues/331), an error occurred due to the lack of support for boolean data types.
- I have added `ElementType::Bool` and the necessary utility code for it.