### PR TITLE
feat: mask_where

### DIFF
--- a/burn-autodiff/src/ops/int_tensor.rs
+++ b/burn-autodiff/src/ops/int_tensor.rs
@@ -229,12 +229,12 @@ impl<B: Backend> IntTensorOps<ADBackendDecorator<B>> for ADBackendDecorator<B> {
         B::int_index_select_dim_assign(tensor, dim, indexes, value)
     }
 
-    fn int_mask_scatter<const D: usize>(
+    fn int_mask_where<const D: usize>(
         tensor: IntTensor<B, D>,
         mask: BoolTensor<B, D>,
-        source: IntTensor<B, D>,
+        value: IntTensor<B, D>,
     ) -> <ADBackendDecorator<B> as Backend>::IntTensorPrimitive<D> {
-        B::int_mask_scatter(tensor, mask, source)
+        B::int_mask_where(tensor, mask, value)
     }
 
     fn int_mask_fill<const D: usize>(

--- a/burn-autodiff/src/tests/mask.rs
+++ b/burn-autodiff/src/tests/mask.rs
@@ -25,26 +25,29 @@ mod tests {
     }
 
     #[test]
-    fn should_diff_mask_scatter() {
-        let data_1 = Data::<f32, 2>::from([[1.0, 7.0], [2.0, 3.0]]);
-        let data_2 = Data::<f32, 2>::from([[4.0, 7.0], [2.0, 3.0]]);
-        let mask = Data::<bool, 2>::from([[true, false], [false, true]]);
+    fn should_diff_mask_where() {
+        let tensor_1 = TestADTensor::from_data([[1.0, 7.0], [2.0, 3.0]]).require_grad();
+        let tensor_2 = TestADTensor::from_data([[4.0, 7.0], [2.0, 3.0]]).require_grad();
+        let tensor_3 = TestADTensor::from_data([[8.8, 9.8], [10.8, 11.8]]).require_grad();
+        let mask = TestADTensor::from_data([[true, false], [false, true]]);
 
-        let data_source = Data::<f32, 2>::from([[8.8, 8.8], [8.8, 8.8]]);
-
-        let tensor_1 = TestADTensor::from_data(data_1).require_grad();
-        let tensor_2 = TestADTensor::from_data(data_2).require_grad();
-        let tensor_source = TestADTensor::from_data(data_source).require_grad();
-        let mask = TestADTensor::from_bool(mask);
-
-        let tensor_3 = tensor_1.clone().matmul(tensor_2.clone());
-        let tensor_4 = tensor_3.mask_scatter(mask, tensor_source);
-        let grads = tensor_4.backward();
+        let tensor_4 = tensor_1.clone().matmul(tensor_2.clone());
+        let tensor_5 = tensor_4.clone().matmul(tensor_3.clone());
+        let tensor_6 = tensor_5.mask_where(mask, tensor_3.clone());
+        let grads = tensor_6.backward();
 
         let grad_1 = tensor_1.grad(&grads).unwrap();
         let grad_2 = tensor_2.grad(&grads).unwrap();
+        let grad_3 = tensor_3.grad(&grads).unwrap();
 
-        assert_eq!(grad_1.to_data(), Data::from([[7.0, 3.0], [4.0, 2.0]]));
-        assert_eq!(grad_2.to_data(), Data::from([[2.0, 1.0], [3.0, 7.0]]));
+        grad_1
+            .into_data()
+            .assert_approx_eq(&Data::from([[121.8, 55.0], [110.8, 50.0]]), 3);
+        grad_2
+            .into_data()
+            .assert_approx_eq(&Data::from([[27.4, 33.4], [95.0, 115.0]]), 3);
+        grad_3
+            .into_data()
+            .assert_approx_eq(&Data::from([[15., 18.], [23., 29.]]), 3);
     }
 }

--- a/burn-ndarray/src/ops/base.rs
+++ b/burn-ndarray/src/ops/base.rs
@@ -293,7 +293,7 @@ where
         output
     }
 
-    pub fn mask_scatter<const D: usize>(
+    pub fn mask_where<const D: usize>(
         tensor: NdArrayTensor<E, D>,
         mask: NdArrayTensor<bool, D>,
         source: NdArrayTensor<E, D>,

--- a/burn-ndarray/src/ops/int_tensor.rs
+++ b/burn-ndarray/src/ops/int_tensor.rs
@@ -72,12 +72,12 @@ impl<E: FloatNdArrayElement> IntTensorOps<NdArrayBackend<E>> for NdArrayBackend<
         NdArrayTensor::from_data(Data::new(values, shape))
     }
 
-    fn int_mask_scatter<const D: usize>(
+    fn int_mask_where<const D: usize>(
         tensor: NdArrayTensor<i64, D>,
         mask: NdArrayTensor<bool, D>,
         source: NdArrayTensor<i64, D>,
     ) -> NdArrayTensor<i64, D> {
-        NdArrayMathOps::mask_scatter(tensor, mask, source)
+        NdArrayMathOps::mask_where(tensor, mask, source)
     }
 
     fn int_mask_fill<const D: usize>(

--- a/burn-ndarray/src/ops/tensor.rs
+++ b/burn-ndarray/src/ops/tensor.rs
@@ -200,12 +200,12 @@ impl<E: FloatNdArrayElement> TensorOps<NdArrayBackend<E>> for NdArrayBackend<E> 
         NdArrayOps::index_assign(tensor, indexes, value)
     }
 
-    fn mask_scatter<const D: usize>(
+    fn mask_where<const D: usize>(
         tensor: NdArrayTensor<E, D>,
         mask: NdArrayTensor<bool, D>,
-        source: NdArrayTensor<E, D>,
+        value: NdArrayTensor<E, D>,
     ) -> NdArrayTensor<E, D> {
-        NdArrayMathOps::mask_scatter(tensor, mask, source)
+        NdArrayMathOps::mask_where(tensor, mask, value)
     }
 
     fn mask_fill<const D: usize>(

--- a/burn-tch/src/ops/int_tensor.rs
+++ b/burn-tch/src/ops/int_tensor.rs
@@ -265,7 +265,7 @@ impl<E: TchElement> IntTensorOps<TchBackend<E>> for TchBackend<E> {
         TchOps::index_select_dim_assign(tensor, dim, indexes, value)
     }
 
-    fn int_mask_scatter<const D: usize>(
+    fn int_mask_where<const D: usize>(
         tensor: TchTensor<i64, D>,
         mask: TchTensor<bool, D>,
         source: TchTensor<i64, D>,

--- a/burn-tch/src/ops/tensor.rs
+++ b/burn-tch/src/ops/tensor.rs
@@ -225,18 +225,14 @@ impl<E: TchElement> TensorOps<TchBackend<E>> for TchBackend<E> {
         TchOps::index_assign(tensor, indexes, value)
     }
 
-    fn mask_scatter<const D: usize>(
+    fn mask_where<const D: usize>(
         tensor: TchTensor<E, D>,
         mask: TchTensor<bool, D>,
-        source: TchTensor<E, D>,
+        value: TchTensor<E, D>,
     ) -> TchTensor<E, D> {
-        TchTensor::binary_ops_tensor(
-            tensor,
-            source,
-            |tensor, source| tensor.f_masked_scatter_(&mask.tensor, source).unwrap(),
-            |tensor, source| tensor.f_masked_scatter(&mask.tensor, source).unwrap(),
-            |tensor, source| tensor.f_masked_scatter(&mask.tensor, source).unwrap(),
-        )
+        let output = value.tensor.where_self(&mask.tensor, &tensor.tensor);
+
+        TchTensor::new(output)
     }
 
     fn mask_fill<const D: usize>(

--- a/burn-tensor/src/tensor/api/numeric.rs
+++ b/burn-tensor/src/tensor/api/numeric.rs
@@ -198,12 +198,18 @@ where
         K::lower_equal_elem(self.primitive, other.elem())
     }
 
-    /// Fill elements from the given tensor based where the mask is true.
-    pub fn mask_scatter(self, mask: Tensor<B, D, Bool>, source: Self) -> Self {
-        Self::new(K::mask_scatter(self.primitive, mask, source.primitive))
+    /// Update the given tensor with the value tensor where the mask is true.
+    ///
+    /// This is similar to [mask_fill](Tensor::mask_fill), however the value is a tensor instead of
+    /// a scalar.
+    pub fn mask_where(self, mask: Tensor<B, D, Bool>, value: Self) -> Self {
+        Self::new(K::mask_where(self.primitive, mask, value.primitive))
     }
 
-    /// Fill each element with the given value based on the given mask.
+    /// Update the given tensor with the value where the mask is true.
+    ///
+    /// This is similar to [mask_where](Tensor::mask_where), however the value is a scalar instead of
+    /// a tensor.
     pub fn mask_fill<E: ElementConversion>(self, mask: Tensor<B, D, Bool>, value: E) -> Self {
         Self::new(K::mask_fill(self.primitive, mask, value.elem()))
     }
@@ -446,7 +452,7 @@ where
         lhs: Self::Primitive<D>,
         rhs: Self::Elem,
     ) -> Tensor<B, D, Bool>;
-    fn mask_scatter<const D: usize>(
+    fn mask_where<const D: usize>(
         tensor: Self::Primitive<D>,
         mask: Tensor<B, D, Bool>,
         source: Self::Primitive<D>,
@@ -621,12 +627,12 @@ impl<B: Backend> Numeric<B> for Int {
         Tensor::new(B::int_lower_equal_elem(lhs, rhs))
     }
 
-    fn mask_scatter<const D: usize>(
+    fn mask_where<const D: usize>(
         tensor: Self::Primitive<D>,
         mask: Tensor<B, D, Bool>,
         source: Self::Primitive<D>,
     ) -> Self::Primitive<D> {
-        B::int_mask_scatter(tensor, mask.primitive, source)
+        B::int_mask_where(tensor, mask.primitive, source)
     }
 
     fn mask_fill<const D: usize>(
@@ -842,12 +848,12 @@ impl<B: Backend> Numeric<B> for Float {
         Tensor::new(B::lower_equal_elem(lhs, rhs))
     }
 
-    fn mask_scatter<const D: usize>(
+    fn mask_where<const D: usize>(
         tensor: Self::Primitive<D>,
         mask: Tensor<B, D, Bool>,
         source: Self::Primitive<D>,
     ) -> Self::Primitive<D> {
-        B::mask_scatter(tensor, mask.primitive, source)
+        B::mask_where(tensor, mask.primitive, source)
     }
 
     fn mask_fill<const D: usize>(

--- a/burn-tensor/src/tensor/ops/int_tensor.rs
+++ b/burn-tensor/src/tensor/ops/int_tensor.rs
@@ -34,7 +34,7 @@ pub trait IntTensorOps<B: Backend> {
         indexes: [Range<usize>; D2],
         value: B::IntTensorPrimitive<D1>,
     ) -> B::IntTensorPrimitive<D1>;
-    fn int_mask_scatter<const D: usize>(
+    fn int_mask_where<const D: usize>(
         tensor: B::IntTensorPrimitive<D>,
         mask: B::BoolTensorPrimitive<D>,
         source: B::IntTensorPrimitive<D>,

--- a/burn-tensor/src/tensor/ops/tensor.rs
+++ b/burn-tensor/src/tensor/ops/tensor.rs
@@ -150,10 +150,10 @@ pub trait TensorOps<B: Backend> {
         indexes: [Range<usize>; D2],
         value: B::TensorPrimitive<D1>,
     ) -> B::TensorPrimitive<D1>;
-    fn mask_scatter<const D: usize>(
+    fn mask_where<const D: usize>(
         tensor: B::TensorPrimitive<D>,
         mask: B::BoolTensorPrimitive<D>,
-        source: B::TensorPrimitive<D>,
+        value: B::TensorPrimitive<D>,
     ) -> B::TensorPrimitive<D>;
     fn mask_fill<const D: usize>(
         tensor: B::TensorPrimitive<D>,

--- a/burn-tensor/src/tests/ops/mask.rs
+++ b/burn-tensor/src/tests/ops/mask.rs
@@ -4,14 +4,13 @@ mod tests {
     use burn_tensor::{Bool, Data, Tensor};
 
     #[test]
-    fn should_support_mask_scatter_ops() {
+    fn should_support_mask_where_ops() {
         let tensor = Tensor::<TestBackend, 2>::from_data(Data::from([[1.0, 7.0], [2.0, 3.0]]));
         let mask =
             Tensor::<TestBackend, 2, Bool>::from_bool(Data::from([[true, false], [false, true]]));
+        let value = Tensor::<TestBackend, 2>::from_data(Data::from([[8.8, 8.8], [8.8, 8.8]]));
 
-        let source = Tensor::<TestBackend, 2>::from_data(Data::from([[8.8, 8.8], [8.8, 8.8]]));
-
-        let data_actual = tensor.mask_scatter(mask, source).to_data();
+        let data_actual = tensor.mask_where(mask, value).to_data();
 
         let data_expected = Data::from([[8.8, 7.0], [2.0, 8.8]]);
         assert_eq!(data_expected, data_actual);

--- a/burn-wgpu/src/ops/float_ops.rs
+++ b/burn-wgpu/src/ops/float_ops.rs
@@ -206,7 +206,7 @@ where
         BaseOps::<G>::index_assign(tensor, indexes, value)
     }
 
-    fn mask_scatter<const D: usize>(
+    fn mask_where<const D: usize>(
         _tensor: <WGPUBackend<G, F, I> as Backend>::TensorPrimitive<D>,
         _mask: <WGPUBackend<G, F, I> as Backend>::BoolTensorPrimitive<D>,
         _source: <WGPUBackend<G, F, I> as Backend>::TensorPrimitive<D>,

--- a/burn-wgpu/src/ops/int_ops.rs
+++ b/burn-wgpu/src/ops/int_ops.rs
@@ -67,7 +67,7 @@ where
         BaseOps::<G>::index_assign(tensor, indexes, value)
     }
 
-    fn int_mask_scatter<const D: usize>(
+    fn int_mask_where<const D: usize>(
         _tensor: <WGPUBackend<G, F, I> as Backend>::IntTensorPrimitive<D>,
         _mask: <WGPUBackend<G, F, I> as Backend>::BoolTensorPrimitive<D>,
         _source: <WGPUBackend<G, F, I> as Backend>::IntTensorPrimitive<D>,


### PR DESCRIPTION
Replace mask_scatter with mask_where.

The mask_scatter was implemented such that it was mask_where. Since mask_where is more common than mask_scatter, I just replaced the function. I added better tests and updated the doc. The is similar to https://pytorch.org/docs/stable/generated/torch.where.html?highlight=where#torch.where however the mask is reversed to be more inline with mask_fill, otherwise it would be the inverse.