### PR TITLE
Clean up the main readme to pop a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,74 +8,71 @@
 [![Rust Version](https://img.shields.io/badge/Rust-1.65.0+-blue)](https://releases.rs/docs/1.65.0)
 ![license](https://shields.io/badge/license-MIT%2FApache--2.0-blue)
 
-----
 
-This library strives to serve as a comprehensive **deep learning framework**, offering exceptional flexibility and written in Rust. Our objective is to cater to both researchers and practitioners by simplifying the process of experimenting, training, and deploying models.
+This library strives to serve as a comprehensive **deep learning framework**, offering exceptional
+flexibility and written in Rust. Our objective is to cater to both researchers and practitioners by
+simplifying the process of experimenting, training, and deploying models.
 
 <div align="left">
 
-> *__Disclamer__* _Burn is currently in active development, and there will be breaking changes. While any resulting issues are likely to be easy to fix, there are no guarantees at this stage._
-
-__Sections__
-
-* [Features](#features)
-* [Get Started](#get-started)
-    * [Examples](#examples)
-    * [Components](#components)
-        * [Backend](#backend)
-        * [Tensor](#tensor)
-        * [Autodiff](#autodiff)
-        * [Module](#module)
-        * [Config](#config)
-        * [Learner](#learner)
-* [no_std support](#no_std-support)
-* [Contributing](#contributing)
-* [Sponsors](#sponsors)
-* [License](#license)
-
 ## Features
 
-* Customizable and user-friendly neural network [module](#module) 🔥
-* Comprehensive [training](#learner) capabilities, including `metrics`, `logging`, and `checkpointing` 📈
-* Versatile [Tensor](#tensor) crate with pluggable backends 🔧
-  * [Torch](https://github.com/burn-rs/burn/tree/main/burn-tch) backend offering CPU/GPU support 🚀
-  * [NdArray](https://github.com/burn-rs/burn/tree/main/burn-ndarray) backend featuring [`no_std`](#no_std-support) compatibility for any platform 👌
-  * [Autodiff](https://github.com/burn-rs/burn/tree/main/burn-autodiff) backend enabling differentiability for all backends 🌟
-* [Dataset](https://github.com/burn-rs/burn/tree/main/burn-dataset) crate with a variety of utilities and sources 📚
-* [Import](https://github.com/burn-rs/burn/tree/main/burn-import) crate for seamless integration of pretrained models 📦
+- Customizable and user-friendly neural network [module](#module) 🔥
+- Comprehensive [training](#learner) capabilities, including `metrics`, `logging`, and
+  `checkpointing` 📈
+- Versatile [Tensor](#tensor) crate with pluggable backends 🔧
+  - [Torch](https://github.com/burn-rs/burn/tree/main/burn-tch) backend offering CPU/GPU support 🚀
+  - [NdArray](https://github.com/burn-rs/burn/tree/main/burn-ndarray) backend featuring
+    [`no_std`](#no_std-support) compatibility for any platform 👌
+  - [Autodiff](https://github.com/burn-rs/burn/tree/main/burn-autodiff) backend enabling
+    differentiability for all backends 🌟
+- [Dataset](https://github.com/burn-rs/burn/tree/main/burn-dataset) crate with a variety of
+  utilities and sources 📚
+- [Import](https://github.com/burn-rs/burn/tree/main/burn-import) crate for seamless integration of
+  pretrained models 📦
 
 ## Get Started
 
-The best way to get started with `burn` is to clone the repo and play with the [examples](#examples).
-This may also be a good idea to take a look the main [components](#components) of `burn` to get a quick overview of the fundamental building blocks.
-If you're interested in how the framework works, you can read our [architecture document](https://github.com/burn-rs/burn/tree/main/ARCHITECTURE.md).
+The best way to get started with `burn` is to clone the repo and play with the
+[examples](#examples). This may also be a good idea to take a look the main
+[components](#components) of `burn` to get a quick overview of the fundamental building blocks. If
+you're interested in how the framework works, you can read our
+[architecture document](https://github.com/burn-rs/burn/tree/main/ARCHITECTURE.md).
 
 ### Examples
 
-* [MNIST](https://github.com/burn-rs/burn/tree/main/examples/mnist) train a model on CPU/GPU using different backends.
-* [MNIST Inference Web](https://github.com/burn-rs/burn/tree/main/examples/mnist-inference-web) run trained model in the browser for inference.
-* [Text Classification](https://github.com/burn-rs/burn/tree/main/examples/text-classification) train a transformer encoder from scratch on GPU.
-* [Text Generation](https://github.com/burn-rs/burn/tree/main/examples/text-generation) train an autoregressive transformer from scratch on GPU.
+- [MNIST](https://github.com/burn-rs/burn/tree/main/examples/mnist) train a model on CPU/GPU using
+  different backends.
+- [MNIST Inference Web](https://github.com/burn-rs/burn/tree/main/examples/mnist-inference-web) run
+  trained model in the browser for inference.
+- [Text Classification](https://github.com/burn-rs/burn/tree/main/examples/text-classification)
+  train a transformer encoder from scratch on GPU.
+- [Text Generation](https://github.com/burn-rs/burn/tree/main/examples/text-generation) train an
+  autoregressive transformer from scratch on GPU.
 
 ### Components
 
-Understanding the key components and philosophy of `burn` can greatly help when beginning to work with the framework.
+Understanding the key components and philosophy of `burn` can greatly help when beginning to work
+with the framework.
 
 #### Backend
 
-Nearly everything in `burn` is based on the `Backend` trait, which enables you to run tensor operations using different implementations without having to modify your code.
-While a backend may not necessarily have autodiff capabilities, the `ADBackend` trait specifies when autodiff is needed.
-This trait not only abstracts operations but also tensor, device and element types, providing each backend the flexibility they need.
-It's worth noting that the trait assumes eager mode since `burn` fully supports dynamic graphs.
-However, we may create another API to assist with integrating graph-based backends, without requiring any changes to the user's code.
+Nearly everything in `burn` is based on the `Backend` trait, which enables you to run tensor
+operations using different implementations without having to modify your code. While a backend may
+not necessarily have autodiff capabilities, the `ADBackend` trait specifies when autodiff is needed.
+This trait not only abstracts operations but also tensor, device and element types, providing each
+backend the flexibility they need. It's worth noting that the trait assumes eager mode since `burn`
+fully supports dynamic graphs. However, we may create another API to assist with integrating
+graph-based backends, without requiring any changes to the user's code.
 
 #### Tensor
 
-At the core of burn lies the `Tensor` struct, which encompasses multiple types of tensors, including `Float`, `Int`, and `Bool`.
-The element types of these tensors are specified by the backend and are usually designated as a generic argument (e.g., `NdArrayBackend<f32>`).
-Although the same struct is used for all tensors, the available methods differ depending on the tensor kind.
-You can specify the desired tensor kind by setting the third generic argument, which defaults to `Float`.
-The first generic argument specifies the backend, while the second specifies the number of dimensions.
+At the core of burn lies the `Tensor` struct, which encompasses multiple types of tensors, including
+`Float`, `Int`, and `Bool`. The element types of these tensors are specified by the backend and are
+usually designated as a generic argument (e.g., `NdArrayBackend<f32>`). Although the same struct is
+used for all tensors, the available methods differ depending on the tensor kind. You can specify the
+desired tensor kind by setting the third generic argument, which defaults to `Float`. The first
+generic argument specifies the backend, while the second specifies the number of dimensions.
 
 ```rust
 use burn::tensor::backend::Backend;
@@ -87,13 +84,17 @@ fn function<B: Backend>(tensor_float: Tensor<B, 2>) {
 }
 ```
 
-As demonstrated in the previous example, nearly all operations require owned tensors as parameters, which means that calling `Clone` explicitly is necessary when reusing the same tensor multiple times.
-However, there's no need to worry since the tensor's data won't be copied, it will be flagged as readonly when multiple tensors use the same allocated memory.
-This enables backends to reuse tensor data when possible, similar to a copy-on-write pattern, while remaining completely transparent to the user.
+As demonstrated in the previous example, nearly all operations require owned tensors as parameters,
+which means that calling `Clone` explicitly is necessary when reusing the same tensor multiple
+times. However, there's no need to worry since the tensor's data won't be copied, it will be flagged
+as readonly when multiple tensors use the same allocated memory. This enables backends to reuse
+tensor data when possible, similar to a copy-on-write pattern, while remaining completely
+transparent to the user.
 
 #### Autodiff
 
-The 'Backend' trait is highly flexible, enabling backpropagation to be implemented using a simple backend decorator, which makes any backend differentiable.
+The 'Backend' trait is highly flexible, enabling backpropagation to be implemented using a simple
+backend decorator, which makes any backend differentiable.
 
 ```rust
 use burn::tensor::backend::{ADBackend, Backend};
@@ -127,8 +128,9 @@ fn main() {
 
 #### Module
 
-The `Module` derive allows you to create your own neural network modules, similar to PyTorch.
-The derive function only generates the necessary methods to essentially act as a parameter container for your type, it makes no assumptions about how the forward pass is declared.
+The `Module` derive allows you to create your own neural network modules, similar to PyTorch. The
+derive function only generates the necessary methods to essentially act as a parameter container for
+your type, it makes no assumptions about how the forward pass is declared.
 
 ```rust
 use burn::nn;
@@ -154,12 +156,13 @@ impl<B: Backend> PositionWiseFeedForward<B> {
 }
 ```
 
-Note that all fields declared in the struct must also implement the `Module` trait.
-The `Tensor` struct doesn't implement `Module`, but `Param<Tensor<B, D>>` does.
+Note that all fields declared in the struct must also implement the `Module` trait. The `Tensor`
+struct doesn't implement `Module`, but `Param<Tensor<B, D>>` does.
 
 #### Config
 
-The `Config` derive lets you define serializable and deserializable configurations or hyper-parameters for your [modules](#module) or any components.
+The `Config` derive lets you define serializable and deserializable configurations or
+hyper-parameters for your [modules](#module) or any components.
 
 ```rust
 use burn::config::Config;
@@ -188,8 +191,8 @@ fn main() {
 
 #### Learner
 
-The `Learner` is the main `struct` that let you train a neural network with support for `logging`, `metric`, `checkpointing` and more.
-In order to create a learner, you must use the `LearnerBuilder`.
+The `Learner` is the main `struct` that let you train a neural network with support for `logging`,
+`metric`, `checkpointing` and more. In order to create a learner, you must use the `LearnerBuilder`.
 
 ```rust
 use burn::train::LearnerBuilder;
@@ -220,23 +223,38 @@ See this [example](https://github.com/burn-rs/burn/tree/main/examples/mnist) for
 
 ## no_std support
 
-Burn supports `no_std` with `alloc` for the inference mode with the NDArray backend.
-Simply disable the default features of the `burn` and `burn-ndarray` crates (minimum required to run the inference mode).
-See the [burn-no-std-tests](https://github.com/burn-rs/burn/tree/main/examples/burn-no-std-tests) example as a reference implementation.
+Burn supports `no_std` with `alloc` for the inference mode with the NDArray backend. Simply disable
+the default features of the `burn` and `burn-ndarray` crates (minimum required to run the inference
+mode). See the
+[burn-no-std-tests](https://github.com/burn-rs/burn/tree/main/examples/burn-no-std-tests) example as
+a reference implementation.
 
-Additionally `burn-core` and `burn-tensor` crates support `no_std` with `alloc` if needed to direclty include them as dependencies (the `burn` crates reexports `burn-core` and `burn-tensor`).
-Note, under the `no_std` mode, a random seed is generated during the build time if the seed is not initialized by `Backend::seed` method.
-Additionally, [spin::mutex::Mutex](https://docs.rs/spin/latest/spin/mutex/struct.Mutex.html) is used in place of [std::sync::Mutex](https://doc.rust-lang.org/std/sync/struct.Mutex.html) under the `no_std` mode.
+Additionally `burn-core` and `burn-tensor` crates support `no_std` with `alloc` if needed to
+direclty include them as dependencies (the `burn` crates reexports `burn-core` and `burn-tensor`).
+Note, under the `no_std` mode, a random seed is generated during the build time if the seed is not
+initialized by `Backend::seed` method. Additionally,
+[spin::mutex::Mutex](https://docs.rs/spin/latest/spin/mutex/struct.Mutex.html) is used in place of
+[std::sync::Mutex](https://doc.rust-lang.org/std/sync/struct.Mutex.html) under the `no_std` mode.
 
 ## Contributing
 
-Before contributing, please take a moment to review our [code of conduct](https://github.com/burn-rs/burn/tree/main/CODE-OF-CONDUCT.md).
-It's also highly recommended to read our [architecture document](https://github.com/burn-rs/burn/tree/main/ARCHITECTURE.md), which explains our architectural decisions. Please see more details in our [contributing guide](/CONTRIBUTING.md).
+Before contributing, please take a moment to review our
+[code of conduct](https://github.com/burn-rs/burn/tree/main/CODE-OF-CONDUCT.md). It's also highly
+recommended to read our
+[architecture document](https://github.com/burn-rs/burn/tree/main/ARCHITECTURE.md), which explains
+our architectural decisions. Please see more details in our [contributing guide](/CONTRIBUTING.md).
+
+## Disclamer
+
+Burn is currently in active development, and there will be breaking changes. While any resulting
+issues are likely to be easy to fix, there are no guarantees at this stage.
 
 ## Sponsors
 
-You can sponsor the founder of Burn from his [GitHub Sponsors profile](https://github.com/sponsors/nathanielsimard).
-The Burn-rs organization doesn't yet have a fiscal entity, but other sponsor methods might become available as the project grows.
+You can sponsor the founder of Burn from his
+[GitHub Sponsors profile](https://github.com/sponsors/nathanielsimard). The Burn-rs organization
+doesn't yet have a fiscal entity, but other sponsor methods might become available as the project
+grows.
 
 Thanks to all current sponsors 🙏.
 
@@ -245,5 +263,5 @@ Thanks to all current sponsors 🙏.
 ## License
 
 Burn is distributed under the terms of both the MIT license and the Apache License (Version 2.0).
-See [LICENSE-APACHE](./LICENSE-APACHE) and [LICENSE-MIT](./LICENSE-MIT) for details.
-Opening a pull request is assumed to signal agreement with these licensing terms.
+See [LICENSE-APACHE](./LICENSE-APACHE) and [LICENSE-MIT](./LICENSE-MIT) for details. Opening a pull
+request is assumed to signal agreement with these licensing terms.


### PR DESCRIPTION
Removed the sections because it's too long now and steals valuable estate. Plus it was redundant because GitHub renders sections automatically.

Also formatted the document to follow the page margins rules.