### PR TITLE
Perf/unary binary

### DIFF
--- a/burn-tensor/src/tests/ops/log1p.rs
+++ b/burn-tensor/src/tests/ops/log1p.rs
@@ -4,7 +4,7 @@ mod tests {
     use burn_tensor::{Data, Tensor};
 
     #[test]
-    fn should_support_exp_ops() {
+    fn should_support_exp_log1p() {
         let data = Data::from([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
         let tensor = Tensor::<TestBackend, 2>::from_data(data);
 

--- a/burn-wgpu/Cargo.toml
+++ b/burn-wgpu/Cargo.toml
@@ -38,3 +38,4 @@ burn-autodiff = {path = "../burn-autodiff", version = "0.8.0", default-features 
 burn-tensor = {path = "../burn-tensor", version = "0.8.0", default-features = false, features = [
   "export_tests",
 ]}
+burn-ndarray = {path = "../burn-ndarray", version = "0.8.0"}

--- a/burn-wgpu/src/kernel/base.rs
+++ b/burn-wgpu/src/kernel/base.rs
@@ -137,17 +137,10 @@ pub(crate) fn build_info<E: WgpuElement, const D: usize>(
 pub(crate) fn elemwise_workgroup(num_elems: usize, workgroup_size: usize) -> WorkGroup {
     let num_elem_per_invocation = workgroup_size * workgroup_size;
     let workgroups = f32::ceil(num_elems as f32 / num_elem_per_invocation as f32);
-    let workgroup_x = f32::ceil(f32::sqrt(workgroups)) as u32;
-    let mut workgroup_y = workgroup_x;
+    let workgroup_x = f32::ceil(f32::sqrt(workgroups));
+    let workgroup_y = f32::ceil(num_elems as f32 / (workgroup_x * num_elem_per_invocation as f32));
 
-    if workgroup_y > 1 {
-        let num_total_covered = workgroup_x * workgroup_y * num_elem_per_invocation as u32;
-        if num_total_covered as usize - workgroup_size > num_elems {
-            workgroup_y -= 1;
-        }
-    }
-
-    WorkGroup::new(workgroup_x, workgroup_y, 1)
+    WorkGroup::new(workgroup_x as u32, workgroup_y as u32, 1)
 }
 
 #[cfg(test)]

--- a/burn-wgpu/src/kernel/binary_elemwise.rs
+++ b/burn-wgpu/src/kernel/binary_elemwise.rs
@@ -61,7 +61,7 @@ pub fn binary_elemwise<K: StaticKernel, E: WgpuElement, const D: usize, const WO
     lhs: WgpuTensor<E, D>,
     rhs: WgpuTensor<E, D>,
 ) -> WgpuTensor<E, D> {
-    lhs.assert_is_on_save_device(&rhs);
+    lhs.assert_is_on_same_device(&rhs);
 
     let mut shape_out = [0; D];
     lhs.shape
@@ -116,7 +116,7 @@ pub fn binary_elemwise_inplace<
     lhs: WgpuTensor<E, D>,
     rhs: WgpuTensor<E, D>,
 ) -> WgpuTensor<E, D> {
-    lhs.assert_is_on_save_device(&rhs);
+    lhs.assert_is_on_same_device(&rhs);
 
     let kernel = lhs
         .context

--- a/burn-wgpu/src/kernel/binary_elemwise.rs
+++ b/burn-wgpu/src/kernel/binary_elemwise.rs
@@ -1,5 +1,5 @@
-use super::{build_info, KernelSettings, StaticKernel};
-use crate::{context::WorkGroup, element::WgpuElement, kernel_wgsl, tensor::WgpuTensor};
+use super::{build_info, elemwise_workgroup, KernelSettings, StaticKernel};
+use crate::{element::WgpuElement, kernel_wgsl, tensor::WgpuTensor};
 use burn_tensor::Shape;
 
 kernel_wgsl!(BinaryElemwiseRaw, "../template/binary_elemwise.wgsl");
@@ -21,10 +21,7 @@ macro_rules! binary_elemwise {
             fn source_template() -> $crate::kernel::SourceTemplate {
                 $crate::kernel::BinaryElemwiseRaw::source_template().register(
                     "body",
-                    format!(
-                        "output[global_id.x] = lhs[index_lhs] {} rhs[index_rhs];",
-                        $ops
-                    ),
+                    format!("output[id] = lhs[index_lhs] {} rhs[index_rhs];", $ops),
                 )
             }
         }
@@ -44,21 +41,26 @@ macro_rules! binary_elemwise_inplace {
             fn source_template() -> $crate::kernel::SourceTemplate {
                 $crate::kernel::BinaryElemwiseInplaceRaw::source_template().register(
                     "body",
-                    format!(
-                        "lhs[global_id.x] = lhs[global_id.x] {} rhs[index_rhs];",
-                        $ops
-                    ),
+                    format!("lhs[id] = lhs[id] {} rhs[index_rhs];", $ops),
                 )
             }
         }
     };
 }
 
-pub fn binary_elemwise<K: StaticKernel, E: WgpuElement, const D: usize>(
+/// Execute a binary kernel using the default settings.
+pub fn binary_elemwise_default<K: StaticKernel, E: WgpuElement, const D: usize>(
     lhs: WgpuTensor<E, D>,
     rhs: WgpuTensor<E, D>,
 ) -> WgpuTensor<E, D> {
-    const WORKGROUP: usize = 256;
+    binary_elemwise::<K, E, D, 32>(lhs, rhs)
+}
+
+/// Execute a binary kernel using the provided WORKGROUP.
+pub fn binary_elemwise<K: StaticKernel, E: WgpuElement, const D: usize, const WORKGROUP: usize>(
+    lhs: WgpuTensor<E, D>,
+    rhs: WgpuTensor<E, D>,
+) -> WgpuTensor<E, D> {
     lhs.assert_is_on_save_device(&rhs);
 
     let mut shape_out = [0; D];
@@ -72,65 +74,109 @@ pub fn binary_elemwise<K: StaticKernel, E: WgpuElement, const D: usize>(
         });
 
     let shape_out = Shape::new(shape_out);
+    let num_elems = shape_out.num_elements();
 
     let buffer = lhs
         .context
-        .create_buffer(shape_out.num_elements() * core::mem::size_of::<E>());
+        .create_buffer(num_elems * core::mem::size_of::<E>());
     let output = WgpuTensor::new(lhs.context.clone(), shape_out, buffer);
 
     let kernel = lhs
         .context
-        .compile_static::<KernelSettings<K, E, i32, WORKGROUP, 1, 1>>();
+        .compile_static::<KernelSettings<K, E, i32, WORKGROUP, WORKGROUP, 1>>();
     let info = build_info(&[&lhs, &rhs, &output]);
     let info_buffers = lhs
         .context
         .create_buffer_with_data(bytemuck::cast_slice(&info));
 
     lhs.context.execute(
-        WorkGroup::new(
-            f32::ceil(output.shape.num_elements() as f32 / WORKGROUP as f32) as u32,
-            1,
-            1,
-        ),
+        elemwise_workgroup(num_elems, WORKGROUP),
         kernel,
         &[&lhs.buffer, &rhs.buffer, &output.buffer, &info_buffers],
     );
 
     output
 }
-pub fn binary_elemwise_inplace<K: StaticKernel, E: WgpuElement, const D: usize>(
+
+/// Execute a binary inplace kernel using the default settings.
+pub fn binary_elemwise_inplace_default<K: StaticKernel, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<E, D>,
+    rhs: WgpuTensor<E, D>,
+) -> WgpuTensor<E, D> {
+    binary_elemwise_inplace::<K, E, D, 32>(lhs, rhs)
+}
+
+/// Execute a binary inplace kernel using the provided WORKGROUP.
+pub fn binary_elemwise_inplace<
+    K: StaticKernel,
+    E: WgpuElement,
+    const D: usize,
+    const WORKGROUP: usize,
+>(
     lhs: WgpuTensor<E, D>,
     rhs: WgpuTensor<E, D>,
 ) -> WgpuTensor<E, D> {
     lhs.assert_is_on_save_device(&rhs);
 
-    let mut shape_out = [0; D];
-    lhs.shape
-        .dims
-        .iter()
-        .zip(rhs.shape.dims.iter())
-        .enumerate()
-        .for_each(|(index, (dim_lhs, dim_rhs))| {
-            shape_out[index] = usize::max(*dim_lhs, *dim_rhs);
-        });
-
     let kernel = lhs
         .context
-        .compile_static::<KernelSettings<K, E, i32, 256, 1, 1>>();
+        .compile_static::<KernelSettings<K, E, i32, WORKGROUP, WORKGROUP, 1>>();
     let info = build_info(&[&lhs, &rhs]);
     let info_buffers = lhs
         .context
         .create_buffer_with_data(bytemuck::cast_slice(&info));
 
     lhs.context.execute(
-        WorkGroup::new(
-            f32::ceil(lhs.shape.num_elements() as f32 / 256_f32) as u32,
-            1,
-            1,
-        ),
+        elemwise_workgroup(lhs.shape.num_elements(), WORKGROUP),
         kernel,
         &[&lhs.buffer, &rhs.buffer, &info_buffers],
     );
 
     lhs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::{ReferenceBackend, TestBackend};
+    use burn_tensor::{Distribution, Tensor};
+
+    binary_elemwise!(TestKernel, "*");
+    binary_elemwise_inplace!(TestKernelInplace, "*");
+
+    #[test]
+    fn binary_should_work_with_multiple_invocations() {
+        let lhs = Tensor::<TestBackend, 2>::random([6, 256], Distribution::Standard);
+        let rhs = Tensor::<TestBackend, 2>::random([6, 256], Distribution::Standard);
+        let lhs_ref = Tensor::<ReferenceBackend, 2>::from_data(lhs.to_data());
+        let rhs_ref = Tensor::<ReferenceBackend, 2>::from_data(rhs.to_data());
+
+        let actual =
+            binary_elemwise::<TestKernel, _, 2, 16>(lhs.into_primitive(), rhs.into_primitive());
+        let expected = lhs_ref * rhs_ref;
+
+        expected.into_data().assert_approx_eq(
+            &Tensor::<TestBackend, 2>::from_primitive(actual).into_data(),
+            3,
+        );
+    }
+
+    #[test]
+    fn binary_inplace_should_work_with_multiple_invocations() {
+        let lhs = Tensor::<TestBackend, 2>::random([6, 256], Distribution::Standard);
+        let rhs = Tensor::<TestBackend, 2>::random([6, 256], Distribution::Standard);
+        let lhs_ref = Tensor::<ReferenceBackend, 2>::from_data(lhs.to_data());
+        let rhs_ref = Tensor::<ReferenceBackend, 2>::from_data(rhs.to_data());
+
+        let actual = binary_elemwise_inplace::<TestKernelInplace, _, 2, 16>(
+            lhs.into_primitive(),
+            rhs.into_primitive(),
+        );
+        let expected = lhs_ref * rhs_ref;
+
+        expected.into_data().assert_approx_eq(
+            &Tensor::<TestBackend, 2>::from_primitive(actual).into_data(),
+            3,
+        );
+    }
 }

--- a/burn-wgpu/src/kernel/comparison.rs
+++ b/burn-wgpu/src/kernel/comparison.rs
@@ -62,7 +62,7 @@ pub fn comparison<K: StaticKernel, E: WgpuElement, const D: usize>(
     lhs: WgpuTensor<E, D>,
     rhs: WgpuTensor<E, D>,
 ) -> WgpuTensor<u32, D> {
-    lhs.assert_is_on_save_device(&rhs);
+    lhs.assert_is_on_same_device(&rhs);
 
     let mut shape_out = [0; D];
     lhs.shape
@@ -106,7 +106,7 @@ pub fn comparison_inplace<K: StaticKernel, E: WgpuElement, const D: usize>(
     lhs: WgpuTensor<E, D>,
     rhs: WgpuTensor<E, D>,
 ) -> WgpuTensor<u32, D> {
-    lhs.assert_is_on_save_device(&rhs);
+    lhs.assert_is_on_same_device(&rhs);
 
     let kernel = lhs
         .context

--- a/burn-wgpu/src/kernel/matmul.rs
+++ b/burn-wgpu/src/kernel/matmul.rs
@@ -10,7 +10,7 @@ pub fn matmul<E: WgpuElement, const D: usize>(
     lhs: WgpuTensor<E, D>,
     rhs: WgpuTensor<E, D>,
 ) -> WgpuTensor<E, D> {
-    lhs.assert_is_on_save_device(&rhs);
+    lhs.assert_is_on_same_device(&rhs);
     let mut shape_out = [0; D];
     lhs.shape
         .dims

--- a/burn-wgpu/src/kernel/unary.rs
+++ b/burn-wgpu/src/kernel/unary.rs
@@ -16,10 +16,7 @@ macro_rules! unary {
         impl $crate::kernel::StaticKernel for $struct {
             fn source_template() -> $crate::kernel::SourceTemplate {
                 let source = $crate::kernel::UnaryRaw::source_template();
-                source.register(
-                    "body",
-                    format!("output[global_id.x] = {}(input[global_id.x]);", $func),
-                )
+                source.register("body", format!("output[id] = {}(input[id]);", $func))
             }
         }
     };
@@ -45,10 +42,7 @@ macro_rules! unary {
         impl $crate::kernel::StaticKernel for $struct {
             fn source_template() -> $crate::kernel::SourceTemplate {
                 $crate::kernel::UnaryRaw::source_template()
-                    .register(
-                        "body",
-                        format!("output[global_id.x] = {}(input[global_id.x]);", $func),
-                    )
+                    .register("body", format!("output[id] = {}(input[id]);", $func))
                     .add_template(include_str!($file))
             }
         }
@@ -66,10 +60,8 @@ macro_rules! unary_inplace {
 
         impl $crate::kernel::StaticKernel for $struct {
             fn source_template() -> $crate::kernel::SourceTemplate {
-                $crate::kernel::UnaryInplaceRaw::source_template().register(
-                    "body",
-                    format!("input[global_id.x] = {}(input[global_id.x]);", $func),
-                )
+                $crate::kernel::UnaryInplaceRaw::source_template()
+                    .register("body", format!("input[id] = {}(input[id]);", $func))
             }
         }
     };
@@ -95,22 +87,53 @@ macro_rules! unary_inplace {
         impl $crate::kernel::StaticKernel for $struct {
             fn source_template() -> $crate::kernel::SourceTemplate {
                 $crate::kernel::UnaryInplaceRaw::source_template()
-                    .register(
-                        "body",
-                        format!("input[global_id.x] = {}(input[global_id.x]);", $func),
-                    )
+                    .register("body", format!("input[id] = {}(input[id]);", $func))
                     .add_template(include_str!($file))
             }
         }
     };
 }
 
-pub fn unary<K: StaticKernel, E: WgpuElement, const D: usize>(
+/// Execute a unary kernel using the default settings.
+pub fn unary_default<K: StaticKernel, E: WgpuElement, const D: usize>(
     input: WgpuTensor<E, D>,
 ) -> WgpuTensor<E, D> {
+    unary::<K, E, D, 32>(input)
+}
+
+/// Execute a unary inplace kernel using the default settings.
+pub fn unary_inplace_default<K: StaticKernel, E: WgpuElement, const D: usize>(
+    input: WgpuTensor<E, D>,
+) -> WgpuTensor<E, D> {
+    unary_inplace::<K, E, D, 32>(input)
+}
+
+/// Execute a unary inplace kernel using the given WORKGROUP.
+pub fn unary_inplace<K: StaticKernel, E: WgpuElement, const D: usize, const WORKGROUP: usize>(
+    input: WgpuTensor<E, D>,
+) -> WgpuTensor<E, D> {
+    let num_elems = input.shape.num_elements();
+    let kernel = input
+        .context
+        .compile_static::<KernelSettings<K, E, i32, WORKGROUP, WORKGROUP, 1>>();
+
+    input.context.execute(
+        unary_workgroup(num_elems, WORKGROUP),
+        kernel,
+        &[&input.buffer],
+    );
+
+    input
+}
+
+/// Execute a unary kernel using the provided WORKGROUP.
+pub fn unary<K: StaticKernel, E: WgpuElement, const D: usize, const WORKGROUP: usize>(
+    input: WgpuTensor<E, D>,
+) -> WgpuTensor<E, D> {
+    let num_elems = input.shape.num_elements();
     let buffer = input
         .context
-        .create_buffer(input.shape.num_elements() * core::mem::size_of::<E>());
+        .create_buffer(num_elems * core::mem::size_of::<E>());
     let mut output = WgpuTensor::new(input.context.clone(), input.shape, buffer);
     // Since we don't handle the stride inside the kernel, the output tensor have the same strides
     // as the input tensor. It might not be in the default format.
@@ -118,14 +141,10 @@ pub fn unary<K: StaticKernel, E: WgpuElement, const D: usize>(
 
     let kernel = input
         .context
-        .compile_static::<KernelSettings<K, E, i32, 256, 1, 1>>();
+        .compile_static::<KernelSettings<K, E, i32, WORKGROUP, WORKGROUP, 1>>();
 
     input.context.execute(
-        WorkGroup::new(
-            f32::ceil(output.shape.num_elements() as f32 / 256_f32) as u32,
-            1,
-            1,
-        ),
+        unary_workgroup(num_elems, WORKGROUP),
         kernel,
         &[&input.buffer, &output.buffer],
     );
@@ -133,22 +152,56 @@ pub fn unary<K: StaticKernel, E: WgpuElement, const D: usize>(
     output
 }
 
-pub fn unary_inplace<K: StaticKernel, E: WgpuElement, const D: usize>(
-    input: WgpuTensor<E, D>,
-) -> WgpuTensor<E, D> {
-    let kernel = input
-        .context
-        .compile_static::<KernelSettings<K, E, i32, 256, 1, 1>>();
+pub(crate) fn unary_workgroup(num_elems: usize, workgroup_size: usize) -> WorkGroup {
+    let num_elem_per_invocation = workgroup_size * workgroup_size;
+    let workgroups = f32::ceil(num_elems as f32 / num_elem_per_invocation as f32);
+    let workgroup_x = f32::ceil(f32::sqrt(workgroups)) as u32;
+    let mut workgroup_y = workgroup_x;
 
-    input.context.execute(
-        WorkGroup::new(
-            f32::ceil(input.shape.num_elements() as f32 / 256_f32) as u32,
-            1,
-            1,
-        ),
-        kernel,
-        &[&input.buffer],
-    );
+    if workgroup_y > 1 {
+        let num_total_covered = workgroup_x * workgroup_y * num_elem_per_invocation as u32;
+        if num_total_covered as usize - workgroup_size > num_elems {
+            workgroup_y -= 1;
+        }
+    }
 
-    input
+    WorkGroup::new(workgroup_x, workgroup_y, 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::{ReferenceBackend, TestBackend};
+    use burn_tensor::{Distribution, Tensor};
+
+    unary!(TestKernel, func "log");
+    unary_inplace!(TestKernelInplace, func "log");
+
+    #[test]
+    fn unary_should_work_with_multiple_invocations() {
+        let tensor = Tensor::<TestBackend, 2>::random([6, 256], Distribution::Standard);
+        let tensor_ref = Tensor::<ReferenceBackend, 2>::from_data(tensor.to_data());
+
+        let actual = unary::<TestKernel, _, 2, 16>(tensor.into_primitive());
+        let expected = tensor_ref.log();
+
+        expected.into_data().assert_approx_eq(
+            &Tensor::<TestBackend, 2>::from_primitive(actual).into_data(),
+            3,
+        );
+    }
+
+    #[test]
+    fn unary_inplace_should_work_with_multiple_invocations() {
+        let tensor = Tensor::<TestBackend, 2>::random([6, 256], Distribution::Standard);
+        let tensor_ref = Tensor::<ReferenceBackend, 2>::from_data(tensor.to_data());
+
+        let actual = unary_inplace::<TestKernelInplace, _, 2, 16>(tensor.into_primitive());
+        let expected = tensor_ref.log();
+
+        expected.into_data().assert_approx_eq(
+            &Tensor::<TestBackend, 2>::from_primitive(actual).into_data(),
+            3,
+        );
+    }
 }

--- a/burn-wgpu/src/kernel/unary_scalar.rs
+++ b/burn-wgpu/src/kernel/unary_scalar.rs
@@ -1,4 +1,4 @@
-use super::{unary_workgroup, KernelSettings, StaticKernel};
+use super::{elemwise_workgroup, KernelSettings, StaticKernel};
 use crate::{element::WgpuElement, kernel_wgsl, tensor::WgpuTensor};
 
 kernel_wgsl!(UnaryScalarRaw, "../template/unary_scalar.wgsl");
@@ -127,7 +127,7 @@ pub fn unary_scalar<K: StaticKernel, E: WgpuElement, const D: usize, const WORKG
     let rhs_buffer = lhs.context.create_buffer_with_data(E::as_bytes(&[scalar]));
 
     lhs.context.execute(
-        unary_workgroup(num_elems, WORKGROUP),
+        elemwise_workgroup(num_elems, WORKGROUP),
         kernel,
         &[&lhs.buffer, &rhs_buffer, &output.buffer],
     );
@@ -159,7 +159,10 @@ pub fn unary_scalar_inplace<
     let rhs_buffer = lhs.context.create_buffer_with_data(E::as_bytes(&[scalar]));
 
     lhs.context.execute(
-        unary_workgroup(lhs.shape.num_elements(), WORKGROUP),
+        {
+            let num_elems = lhs.shape.num_elements();
+            elemwise_workgroup(num_elems, WORKGROUP)
+        },
         kernel,
         &[&lhs.buffer, &rhs_buffer],
     );

--- a/burn-wgpu/src/kernel/unary_scalar.rs
+++ b/burn-wgpu/src/kernel/unary_scalar.rs
@@ -1,5 +1,5 @@
-use super::{KernelSettings, StaticKernel};
-use crate::{context::WorkGroup, element::WgpuElement, kernel_wgsl, tensor::WgpuTensor};
+use super::{unary_workgroup, KernelSettings, StaticKernel};
+use crate::{element::WgpuElement, kernel_wgsl, tensor::WgpuTensor};
 
 kernel_wgsl!(UnaryScalarRaw, "../template/unary_scalar.wgsl");
 kernel_wgsl!(
@@ -18,10 +18,8 @@ macro_rules! unary_scalar {
 
         impl $crate::kernel::StaticKernel for $struct {
             fn source_template() -> $crate::kernel::SourceTemplate {
-                $crate::kernel::UnaryScalarRaw::source_template().register(
-                    "body",
-                    format!("output[global_id.x] = lhs[global_id.x] {} rhs;", $ops),
-                )
+                $crate::kernel::UnaryScalarRaw::source_template()
+                    .register("body", format!("output[id] = lhs[id] {} rhs;", $ops))
             }
         }
     };
@@ -34,10 +32,24 @@ macro_rules! unary_scalar {
 
         impl $crate::kernel::StaticKernel for $struct {
             fn source_template() -> $crate::kernel::SourceTemplate {
-                $crate::kernel::UnaryScalarRaw::source_template().register(
-                    "body",
-                    format!("output[global_id.x] = {}(lhs[global_id.x], rhs);", $func),
-                )
+                $crate::kernel::UnaryScalarRaw::source_template()
+                    .register("body", format!("output[id] = {}(lhs[id], rhs);", $func))
+            }
+        }
+    };
+
+    (
+        $struct:ident,
+        func $func:expr,
+        include $file:expr
+    ) => {
+        pub struct $struct;
+
+        impl $crate::kernel::StaticKernel for $struct {
+            fn source_template() -> $crate::kernel::SourceTemplate {
+                $crate::kernel::UnaryScalarRaw::source_template()
+                    .register("body", format!("output[id] = {}(lhs[id], rhs);", $func))
+                    .add_template(include_str!($file))
             }
         }
     };
@@ -54,10 +66,8 @@ macro_rules! unary_scalar_inplace {
 
         impl $crate::kernel::StaticKernel for $struct {
             fn source_template() -> $crate::kernel::SourceTemplate {
-                $crate::kernel::UnaryScalarInplaceRaw::source_template().register(
-                    "body",
-                    format!("lhs[global_id.x] = lhs[global_id.x] {} rhs;", $ops),
-                )
+                $crate::kernel::UnaryScalarInplaceRaw::source_template()
+                    .register("body", format!("lhs[id] = lhs[id] {} rhs;", $ops))
             }
         }
     };
@@ -70,34 +80,54 @@ macro_rules! unary_scalar_inplace {
 
         impl $crate::kernel::StaticKernel for $struct {
             fn source_template() -> $crate::kernel::SourceTemplate {
-                $crate::kernel::UnaryScalarInplaceRaw::source_template().register(
-                    "body",
-                    format!("lhs[global_id.x] = {}(lhs[global_id.x], rhs);", $func),
-                )
+                $crate::kernel::UnaryScalarInplaceRaw::source_template()
+                    .register("body", format!("lhs[id] = {}(lhs[id], rhs);", $func))
+            }
+        }
+    };
+
+    (
+        $struct:ident,
+        func $func:expr,
+        include $file:expr
+    ) => {
+        pub struct $struct;
+
+        impl $crate::kernel::StaticKernel for $struct {
+            fn source_template() -> $crate::kernel::SourceTemplate {
+                $crate::kernel::UnaryScalarInplaceRaw::source_template()
+                    .register("body", format!("lhs[id] = {}(lhs[id], rhs);", $func))
+                    .add_template(include_str!($file))
             }
         }
     };
 }
 
-pub fn unary_scalar<K: StaticKernel, E: WgpuElement, const D: usize>(
+/// Execute a unary scalar kernel using the default settings.
+pub fn unary_scalar_default<K: StaticKernel, E: WgpuElement, const D: usize>(
     lhs: WgpuTensor<E, D>,
     scalar: E,
 ) -> WgpuTensor<E, D> {
+    unary_scalar::<K, E, D, 32>(lhs, scalar)
+}
+
+/// Execute a unary scalar kernel using the provided WORKGROUP.
+pub fn unary_scalar<K: StaticKernel, E: WgpuElement, const D: usize, const WORKGROUP: usize>(
+    lhs: WgpuTensor<E, D>,
+    scalar: E,
+) -> WgpuTensor<E, D> {
+    let num_elems = lhs.shape.num_elements();
     let buffer = lhs
         .context
-        .create_buffer(lhs.shape.num_elements() * core::mem::size_of::<E>());
+        .create_buffer(num_elems * core::mem::size_of::<E>());
     let output = WgpuTensor::new(lhs.context.clone(), lhs.shape, buffer);
     let kernel = lhs
         .context
-        .compile_static::<KernelSettings<K, E, i32, 256, 1, 1>>();
+        .compile_static::<KernelSettings<K, E, i32, WORKGROUP, WORKGROUP, 1>>();
     let rhs_buffer = lhs.context.create_buffer_with_data(E::as_bytes(&[scalar]));
 
     lhs.context.execute(
-        WorkGroup::new(
-            f32::ceil(output.shape.num_elements() as f32 / 256_f32) as u32,
-            1,
-            1,
-        ),
+        unary_workgroup(num_elems, WORKGROUP),
         kernel,
         &[&lhs.buffer, &rhs_buffer, &output.buffer],
     );
@@ -105,24 +135,73 @@ pub fn unary_scalar<K: StaticKernel, E: WgpuElement, const D: usize>(
     output
 }
 
-pub fn unary_scalar_inplace<K: StaticKernel, E: WgpuElement, const D: usize>(
+/// Execute a unary scalar inplace kernel using the default settings.
+pub fn unary_scalar_inplace_default<K: StaticKernel, E: WgpuElement, const D: usize>(
+    lhs: WgpuTensor<E, D>,
+    scalar: E,
+) -> WgpuTensor<E, D> {
+    unary_scalar_inplace::<K, E, D, 32>(lhs, scalar)
+}
+
+/// Execute a unary scalar inplace kernel using the provided WORKGROUP.
+pub fn unary_scalar_inplace<
+    K: StaticKernel,
+    E: WgpuElement,
+    const D: usize,
+    const WORKGROUP: usize,
+>(
     lhs: WgpuTensor<E, D>,
     scalar: E,
 ) -> WgpuTensor<E, D> {
     let kernel = lhs
         .context
-        .compile_static::<KernelSettings<K, E, i32, 256, 1, 1>>();
+        .compile_static::<KernelSettings<K, E, i32, WORKGROUP, WORKGROUP, 1>>();
     let rhs_buffer = lhs.context.create_buffer_with_data(E::as_bytes(&[scalar]));
 
     lhs.context.execute(
-        WorkGroup::new(
-            f32::ceil(lhs.shape.num_elements() as f32 / 256_f32) as u32,
-            1,
-            1,
-        ),
+        unary_workgroup(lhs.shape.num_elements(), WORKGROUP),
         kernel,
         &[&lhs.buffer, &rhs_buffer],
     );
 
     lhs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::{ReferenceBackend, TestBackend};
+    use burn_tensor::{Distribution, Tensor};
+
+    unary_scalar!(TestKernel, ops "*");
+    unary_scalar_inplace!(TestKernelInplace, ops "*");
+
+    #[test]
+    fn unary_scalar_should_work_with_multiple_invocations() {
+        let tensor = Tensor::<TestBackend, 2>::random([6, 256], Distribution::Standard);
+        let tensor_ref = Tensor::<ReferenceBackend, 2>::from_data(tensor.to_data());
+
+        let actual = unary_scalar::<TestKernel, _, 2, 16>(tensor.into_primitive(), 5.0);
+        let expected = tensor_ref.mul_scalar(5.0);
+
+        expected.into_data().assert_approx_eq(
+            &Tensor::<TestBackend, 2>::from_primitive(actual).into_data(),
+            3,
+        );
+    }
+
+    #[test]
+    fn unary_scalar_inplace_should_work_with_multiple_invocations() {
+        let tensor = Tensor::<TestBackend, 2>::random([6, 256], Distribution::Standard);
+        let tensor_ref = Tensor::<ReferenceBackend, 2>::from_data(tensor.to_data());
+
+        let actual =
+            unary_scalar_inplace::<TestKernelInplace, _, 2, 16>(tensor.into_primitive(), 5.0);
+        let expected = tensor_ref.mul_scalar(5.0);
+
+        expected.into_data().assert_approx_eq(
+            &Tensor::<TestBackend, 2>::from_primitive(actual).into_data(),
+            3,
+        );
+    }
 }

--- a/burn-wgpu/src/lib.rs
+++ b/burn-wgpu/src/lib.rs
@@ -32,9 +32,10 @@ mod tests {
     #[cfg(not(target_os = "macos"))]
     type GraphicsApi = Vulkan;
 
-    type TestBackend = WGPUBackend<GraphicsApi, f32, i32>;
-    type TestTensor<const D: usize> = burn_tensor::Tensor<TestBackend, D>;
-    type TestTensorInt<const D: usize> = burn_tensor::Tensor<TestBackend, D, burn_tensor::Int>;
+    pub type TestBackend = WGPUBackend<GraphicsApi, f32, i32>;
+    pub type ReferenceBackend = burn_ndarray::NdArrayBackend<f32>;
+    pub type TestTensor<const D: usize> = burn_tensor::Tensor<TestBackend, D>;
+    pub type TestTensorInt<const D: usize> = burn_tensor::Tensor<TestBackend, D, burn_tensor::Int>;
 
     burn_tensor::testgen_add!();
     burn_tensor::testgen_sub!();

--- a/burn-wgpu/src/ops/activation_ops.rs
+++ b/burn-wgpu/src/ops/activation_ops.rs
@@ -2,7 +2,7 @@ use burn_tensor::ops::ActivationOps;
 
 use crate::{
     element::{FloatElement, IntElement},
-    kernel::{unary, unary_inplace},
+    kernel::{unary_default, unary_inplace_default},
     unary, unary_inplace, GraphicsApi, WGPUBackend,
 };
 
@@ -15,13 +15,13 @@ where
     I: IntElement,
 {
     fn relu<const D: usize>(tensor: FloatTensor<Self, D>) -> FloatTensor<Self, D> {
-        unary!(Relu, body "output[global_id.x] = max(input[global_id.x], 0.0);");
-        unary_inplace!(ReluInplace, body "input[global_id.x] = max(input[global_id.x], 0.0);");
+        unary!(Relu, body "output[id] = max(input[id], 0.0);");
+        unary_inplace!(ReluInplace, body "input[id] = max(input[id], 0.0);");
 
         if tensor.can_mut() {
-            return unary_inplace::<ReluInplace, F, D>(tensor);
+            return unary_inplace_default::<ReluInplace, F, D>(tensor);
         }
 
-        unary::<Relu, F, D>(tensor)
+        unary_default::<Relu, F, D>(tensor)
     }
 }

--- a/burn-wgpu/src/ops/numeric.rs
+++ b/burn-wgpu/src/ops/numeric.rs
@@ -1,6 +1,7 @@
 use crate::kernel::{
-    binary_elemwise, binary_elemwise_inplace, reduction_args_dim, reduction_dim, reduction_sum,
-    unary_scalar_default, unary_scalar_inplace_default, ArgsMax, ArgsMin, MeanDim, SumDim,
+    binary_elemwise_default, binary_elemwise_inplace_default, reduction_args_dim, reduction_dim,
+    reduction_sum, unary_scalar_default, unary_scalar_inplace_default, ArgsMax, ArgsMin, MeanDim,
+    SumDim,
 };
 use crate::pool::get_context;
 use crate::{
@@ -46,14 +47,14 @@ impl<G: GraphicsApi> NumericOps<G> {
         binary_elemwise_inplace!(AddInplace, "+");
 
         if lhs.can_mut_broadcast(&rhs) {
-            return binary_elemwise_inplace::<AddInplace, E, D>(lhs, rhs);
+            return binary_elemwise_inplace_default::<AddInplace, E, D>(lhs, rhs);
         }
 
         if rhs.can_mut_broadcast(&lhs) {
-            return binary_elemwise_inplace::<AddInplace, E, D>(rhs, lhs);
+            return binary_elemwise_inplace_default::<AddInplace, E, D>(rhs, lhs);
         }
 
-        binary_elemwise::<Add, E, D>(lhs, rhs)
+        binary_elemwise_default::<Add, E, D>(lhs, rhs)
     }
 
     pub fn add_scalar<E: WgpuElement, const D: usize>(
@@ -78,10 +79,10 @@ impl<G: GraphicsApi> NumericOps<G> {
         binary_elemwise_inplace!(SubInplace, "-");
 
         if lhs.can_mut_broadcast(&rhs) {
-            return binary_elemwise_inplace::<SubInplace, E, D>(lhs, rhs);
+            return binary_elemwise_inplace_default::<SubInplace, E, D>(lhs, rhs);
         }
 
-        binary_elemwise::<Sub, E, D>(lhs, rhs)
+        binary_elemwise_default::<Sub, E, D>(lhs, rhs)
     }
 
     pub fn sub_scalar<E: WgpuElement, const D: usize>(
@@ -106,14 +107,14 @@ impl<G: GraphicsApi> NumericOps<G> {
         binary_elemwise_inplace!(MulInplace, "*");
 
         if lhs.can_mut_broadcast(&rhs) {
-            return binary_elemwise_inplace::<MulInplace, E, D>(lhs, rhs);
+            return binary_elemwise_inplace_default::<MulInplace, E, D>(lhs, rhs);
         }
 
         if rhs.can_mut_broadcast(&lhs) {
-            return binary_elemwise_inplace::<MulInplace, E, D>(rhs, lhs);
+            return binary_elemwise_inplace_default::<MulInplace, E, D>(rhs, lhs);
         }
 
-        binary_elemwise::<Mul, E, D>(lhs, rhs)
+        binary_elemwise_default::<Mul, E, D>(lhs, rhs)
     }
 
     pub fn mul_scalar<E: WgpuElement, const D: usize>(
@@ -138,10 +139,10 @@ impl<G: GraphicsApi> NumericOps<G> {
         binary_elemwise_inplace!(DivInplace, "/");
 
         if lhs.can_mut_broadcast(&rhs) {
-            return binary_elemwise_inplace::<DivInplace, E, D>(lhs, rhs);
+            return binary_elemwise_inplace_default::<DivInplace, E, D>(lhs, rhs);
         }
 
-        binary_elemwise::<Div, E, D>(lhs, rhs)
+        binary_elemwise_default::<Div, E, D>(lhs, rhs)
     }
 
     pub fn div_scalar<E: WgpuElement, const D: usize>(

--- a/burn-wgpu/src/ops/numeric.rs
+++ b/burn-wgpu/src/ops/numeric.rs
@@ -1,6 +1,6 @@
 use crate::kernel::{
     binary_elemwise, binary_elemwise_inplace, reduction_args_dim, reduction_dim, reduction_sum,
-    unary_scalar, unary_scalar_inplace, ArgsMax, ArgsMin, MeanDim, SumDim,
+    unary_scalar_default, unary_scalar_inplace_default, ArgsMax, ArgsMin, MeanDim, SumDim,
 };
 use crate::pool::get_context;
 use crate::{
@@ -64,10 +64,10 @@ impl<G: GraphicsApi> NumericOps<G> {
         unary_scalar_inplace!(AddScalarInplace, ops "+");
 
         if lhs.can_mut() {
-            return unary_scalar_inplace::<AddScalarInplace, E, D>(lhs, rhs);
+            return unary_scalar_inplace_default::<AddScalarInplace, E, D>(lhs, rhs);
         }
 
-        unary_scalar::<AddScalar, E, D>(lhs, rhs)
+        unary_scalar_default::<AddScalar, E, D>(lhs, rhs)
     }
 
     pub fn sub<E: WgpuElement, const D: usize>(
@@ -92,10 +92,10 @@ impl<G: GraphicsApi> NumericOps<G> {
         unary_scalar_inplace!(SubScalarInplace, ops "-");
 
         if lhs.can_mut() {
-            return unary_scalar_inplace::<SubScalarInplace, E, D>(lhs, rhs);
+            return unary_scalar_inplace_default::<SubScalarInplace, E, D>(lhs, rhs);
         }
 
-        unary_scalar::<SubScalar, E, D>(lhs, rhs)
+        unary_scalar_default::<SubScalar, E, D>(lhs, rhs)
     }
 
     pub fn mul<E: WgpuElement, const D: usize>(
@@ -124,10 +124,10 @@ impl<G: GraphicsApi> NumericOps<G> {
         unary_scalar_inplace!(MulScalarInplace, ops "*");
 
         if lhs.can_mut() {
-            return unary_scalar_inplace::<MulScalarInplace, E, D>(lhs, rhs);
+            return unary_scalar_inplace_default::<MulScalarInplace, E, D>(lhs, rhs);
         }
 
-        unary_scalar::<MulScalar, E, D>(lhs, rhs)
+        unary_scalar_default::<MulScalar, E, D>(lhs, rhs)
     }
 
     pub fn div<E: WgpuElement, const D: usize>(
@@ -152,10 +152,10 @@ impl<G: GraphicsApi> NumericOps<G> {
         unary_scalar_inplace!(DivScalarInplace, ops "/");
 
         if lhs.can_mut() {
-            return unary_scalar_inplace::<DivScalarInplace, E, D>(lhs, rhs);
+            return unary_scalar_inplace_default::<DivScalarInplace, E, D>(lhs, rhs);
         }
 
-        unary_scalar::<DivScalar, E, D>(lhs, rhs)
+        unary_scalar_default::<DivScalar, E, D>(lhs, rhs)
     }
 
     pub fn sum<E: WgpuElement + Element, const D: usize>(

--- a/burn-wgpu/src/template/binary_elemwise.wgsl
+++ b/burn-wgpu/src/template/binary_elemwise.wgsl
@@ -14,9 +14,15 @@ var<storage, read_write> output: array<{{ elem }}>;
 @binding(3)
 var<storage, read> info: array<u32>;
 
+const WORKGROUP_SIZE_Y = {{ workgroup_size_y }}u;
+
 @compute
-@workgroup_size({{ workgroup_size_x }}, 1, 1)
-fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+@workgroup_size({{ workgroup_size_x }}, {{ workgroup_size_y }}, 1)
+fn main(
+    @builtin(global_invocation_id) global_id: vec3<u32>,
+    @builtin(num_workgroups) num_workgroups: vec3<u32>,
+) {
+    let id = global_id.x * (num_workgroups.y * WORKGROUP_SIZE_Y) + global_id.y;
     let dim: u32 = info[0];
     var index_lhs: u32 = 0u;
     var index_rhs: u32 = 0u;
@@ -28,8 +34,8 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
         let shape_lhs = info[i + 3u * dim];
         let shape_rhs = info[i + 4u * dim];
 
-        index_lhs += global_id.x / stride_output % shape_lhs * stride_lhs;
-        index_rhs += global_id.x / stride_output % shape_rhs * stride_rhs;
+        index_lhs += id / stride_output % shape_lhs * stride_lhs;
+        index_rhs += id / stride_output % shape_rhs * stride_rhs;
     }
 
     {{ body }}

--- a/burn-wgpu/src/template/binary_elemwise_inplace.wgsl
+++ b/burn-wgpu/src/template/binary_elemwise_inplace.wgsl
@@ -10,21 +10,24 @@ var<storage, read> rhs: array<{{ elem }}>;
 @binding(2)
 var<storage, read> info: array<u32>;
 
+const WORKGROUP_SIZE_Y = {{ workgroup_size_y }}u;
+
 @compute
-@workgroup_size({{ workgroup_size_x }}, 1, 1)
-fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+@workgroup_size({{ workgroup_size_x }}, {{ workgroup_size_y }}, 1)
+fn main(
+    @builtin(global_invocation_id) global_id: vec3<u32>,
+    @builtin(num_workgroups) num_workgroups: vec3<u32>,
+) {
+    let id = global_id.x * (num_workgroups.y * WORKGROUP_SIZE_Y) + global_id.y;
     let dim: u32 = info[0];
-    var index_lhs: u32 = 0u;
     var index_rhs: u32 = 0u;
 
     for (var i: u32 = 1u; i <= dim; i++) {
         let stride_lhs = info[i];
         let stride_rhs = info[i + dim];
-        let shape_lhs = info[i + 2u * dim];
         let shape_rhs = info[i + 3u * dim];
 
-        index_lhs += global_id.x / stride_lhs % shape_lhs * stride_lhs;
-        index_rhs += global_id.x / stride_lhs % shape_rhs * stride_rhs;
+        index_rhs += id / stride_lhs % shape_rhs * stride_rhs;
     }
 
     {{ body }}

--- a/burn-wgpu/src/template/powf.wgsl
+++ b/burn-wgpu/src/template/powf.wgsl
@@ -1,0 +1,14 @@
+fn powf(lhs: {{ elem }}, rhs: {{ elem }}) -> {{ elem }} {
+    let modulo = rhs % 2.0;
+
+    if (modulo == 0.0) {
+        // Even number
+        return pow(abs(lhs), rhs);
+    } else if (modulo == 1.0) {
+        // Odd number
+        return -1.0 * pow(abs(lhs), rhs);
+    } else {
+        // Float number
+        return pow(lhs, rhs);
+    }
+}

--- a/burn-wgpu/src/template/unary.wgsl
+++ b/burn-wgpu/src/template/unary.wgsl
@@ -7,7 +7,11 @@ var<storage, read> input: array<{{ elem }}>;
 var<storage, read_write> output: array<{{ elem }}>;
 
 @compute
-@workgroup_size({{ workgroup_size_x }}, 1, 1)
-fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+@workgroup_size({{ workgroup_size_x }}, {{ workgroup_size_y }}, 1)
+fn main(
+    @builtin(global_invocation_id) global_id: vec3<u32>, 
+    @builtin(num_workgroups) num_workgroups: vec3<u32>,
+) {
+    let id = global_id.x * (num_workgroups.y * {{ workgroup_size_y }}u) + global_id.y;
     {{ body }}
 }

--- a/burn-wgpu/src/template/unary_inplace.wgsl
+++ b/burn-wgpu/src/template/unary_inplace.wgsl
@@ -3,7 +3,11 @@
 var<storage, read_write> input: array<{{ elem }}>;
 
 @compute
-@workgroup_size({{ workgroup_size_x }}, 1, 1)
-fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+@workgroup_size({{ workgroup_size_x }}, {{ workgroup_size_y }}, 1)
+fn main(
+    @builtin(global_invocation_id) global_id: vec3<u32>, 
+    @builtin(num_workgroups) num_workgroups: vec3<u32>,
+) {
+    let id = global_id.x * (num_workgroups.y * {{ workgroup_size_y }}u) + global_id.y;
     {{ body }}
 }

--- a/burn-wgpu/src/template/unary_scalar.wgsl
+++ b/burn-wgpu/src/template/unary_scalar.wgsl
@@ -11,7 +11,11 @@ var<storage, read> rhs: {{ elem }};
 var<storage, read_write> output: array<{{ elem }}>;
 
 @compute
-@workgroup_size({{ workgroup_size_x }}, 1, 1)
-fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+@workgroup_size({{ workgroup_size_x }}, {{ workgroup_size_y }}, 1)
+fn main(
+    @builtin(global_invocation_id) global_id: vec3<u32>, 
+    @builtin(num_workgroups) num_workgroups: vec3<u32>,
+) {
+    let id = global_id.x * (num_workgroups.y * {{ workgroup_size_y }}u) + global_id.y;
     {{ body }}
 }

--- a/burn-wgpu/src/template/unary_scalar_inplace.wgsl
+++ b/burn-wgpu/src/template/unary_scalar_inplace.wgsl
@@ -7,7 +7,11 @@ var<storage, read_write> lhs: array<{{ elem }}>;
 var<storage, read> rhs: {{ elem }};
 
 @compute
-@workgroup_size({{ workgroup_size_x }}, 1, 1)
-fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+@workgroup_size({{ workgroup_size_x }}, {{ workgroup_size_y }}, 1)
+fn main(
+    @builtin(global_invocation_id) global_id: vec3<u32>, 
+    @builtin(num_workgroups) num_workgroups: vec3<u32>,
+) {
+    let id = global_id.x * (num_workgroups.y * {{ workgroup_size_y }}u) + global_id.y;
     {{ body }}
 }

--- a/burn-wgpu/src/tensor/base.rs
+++ b/burn-wgpu/src/tensor/base.rs
@@ -84,7 +84,7 @@ impl<E: WgpuElement, const D: usize> WgpuTensor<E, D> {
         true
     }
 
-    pub fn assert_is_on_save_device(&self, other: &Self) {
+    pub fn assert_is_on_same_device(&self, other: &Self) {
         if self.context.device != other.context.device {
             panic!(
                 "Both tensors should be on the same device {:?} != {:?}",

--- a/burn-wgpu/src/tensor/base.rs
+++ b/burn-wgpu/src/tensor/base.rs
@@ -3,7 +3,7 @@ use burn_tensor::Shape;
 use std::{marker::PhantomData, sync::Arc};
 use wgpu::Buffer;
 
-use crate::{context::Context, element::WgpuElement, kernel::unary};
+use crate::{context::Context, element::WgpuElement, kernel::unary_default};
 
 #[derive(Debug, Clone)]
 pub struct WgpuTensor<E: WgpuElement, const D: usize> {
@@ -73,7 +73,7 @@ impl<E: WgpuElement, const D: usize> WgpuTensor<E, D> {
         //
         // The solution is just to use a simple unary compute shader.
         unary!(CopyBuffer, body "output[global_id.x] = input[global_id.x];");
-        unary::<CopyBuffer, E, D>(self.clone())
+        unary_default::<CopyBuffer, E, D>(self.clone())
     }
 
     pub fn can_mut(&self) -> bool {


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [X] Confirm that `run-checks.sh` has been executed.

### Changes

How the unary and binary operations work (2D instead of 1D). The problem being 1D is a limitation on the size of tensor (max 65536 * 1024), now it's (65536 * 65536 * 1024)

### Testing

Added some specific tests to check the number of invocation is correct.