### PR TITLE
fix: wgpu cat can support bigger tensors

### DIFF
--- a/burn-wgpu/src/kernel/cat.rs
+++ b/burn-wgpu/src/kernel/cat.rs
@@ -1,7 +1,6 @@
 use crate::{
-    context::WorkGroup,
     element::WgpuElement,
-    kernel::{build_info, KernelSettings},
+    kernel::{build_info, elemwise_workgroup, KernelSettings},
     kernel_wgsl,
     tensor::WgpuTensor,
 };
@@ -12,7 +11,7 @@ pub fn cat<E: WgpuElement, const D: usize>(
     inputs: Vec<WgpuTensor<E, D>>,
     dim: usize,
 ) -> WgpuTensor<E, D> {
-    const WORKGROUP: usize = 256;
+    const WORKGROUP: usize = 32;
 
     let first_input = inputs.get(0).unwrap();
     let context = &first_input.context;
@@ -24,16 +23,11 @@ pub fn cat<E: WgpuElement, const D: usize>(
         .create_buffer(shape_output.num_elements() * std::mem::size_of::<E>());
 
     let output = WgpuTensor::new(context.clone(), shape_output, buffer);
-    let kernel = context.compile_static::<KernelSettings<Cat, E, i32, WORKGROUP, 1, 1>>();
+    let kernel = context.compile_static::<KernelSettings<Cat, E, i32, WORKGROUP, WORKGROUP, 1>>();
 
     let mut dim_cat_index = 0;
 
     for input in inputs.iter() {
-        let workgroup = WorkGroup::new(
-            f32::ceil(input.shape.num_elements() as f32 / WORKGROUP as f32) as u32,
-            1,
-            1,
-        );
         let mut info = build_info(&[input, &output]);
         info.push(dim as u32);
         info.push(dim_cat_index as u32);
@@ -41,11 +35,41 @@ pub fn cat<E: WgpuElement, const D: usize>(
         let info_buffer = context.create_buffer_with_data(bytemuck::cast_slice(&info));
 
         context.execute(
-            workgroup,
+            elemwise_workgroup(input.shape.num_elements(), WORKGROUP),
             kernel.clone(),
             &[&input.buffer, &output.buffer, &info_buffer],
         );
     }
 
     output
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::{ReferenceBackend, TestBackend};
+    use burn_tensor::{Distribution, Tensor};
+
+    #[test]
+    fn cat_should_support_multiple_invokations() {
+        test_same_as_reference([6, 256]);
+    }
+
+    #[test]
+    fn cat_should_support_uneven_launch() {
+        test_same_as_reference([1, 137]);
+    }
+
+    fn test_same_as_reference(shape: [usize; 2]) {
+        let tensor1 = Tensor::<TestBackend, 2>::random(shape, Distribution::Standard);
+        let tensor2 = Tensor::<TestBackend, 2>::random(shape, Distribution::Standard);
+        let tensor1_ref = Tensor::<ReferenceBackend, 2>::from_data(tensor1.to_data());
+        let tensor2_ref = Tensor::<ReferenceBackend, 2>::from_data(tensor2.to_data());
+
+        let tensor = Tensor::<TestBackend, 2>::cat(vec![tensor1, tensor2], 0);
+        let tensor_ref = Tensor::<ReferenceBackend, 2>::cat(vec![tensor1_ref, tensor2_ref], 0);
+
+        tensor
+            .into_data()
+            .assert_approx_eq(&tensor_ref.into_data(), 3);
+    }
 }

--- a/burn-wgpu/src/template/cat.wgsl
+++ b/burn-wgpu/src/template/cat.wgsl
@@ -10,18 +10,21 @@ var<storage, read_write> output: array<{{ elem }}>;
 @binding(2)
 var<storage, read> info: array<u32>;
 
+const WORKGROUP_SIZE_X = {{ workgroup_size_x }}u;
+
 @compute
-@workgroup_size({{ workgroup_size_x }}, 1, 1)
+@workgroup_size({{ workgroup_size_x }}, {{ workgroup_size_y }}, 1)
 fn main(
     @builtin(global_invocation_id) global_id: vec3<u32>,
+    @builtin(num_workgroups) num_workgroups: vec3<u32>,
 ) {
+    let id = global_id.y * (num_workgroups.x * WORKGROUP_SIZE_X) + global_id.x;
     let dim: u32 = info[0];
     let dim_cat = info[4u * dim + 1u];
     let dim_cat_index = info[4u * dim + 2u];
 
     var index_input: u32 = 0u;
     var index_output: u32 = 0u;
-    var num_elem_input = 1u;
 
     for (var i: u32 = 1u; i <= dim; i++) {
         let stride_input = info[i];
@@ -29,9 +32,7 @@ fn main(
         let shape_input = info[i + 2u * dim];
         let shape_output = info[i + 3u * dim];
 
-        num_elem_input *= shape_input;
-
-        let num_block_output = global_id.x / stride_output % shape_output;
+        let num_block_output = id / stride_output % shape_output;
         index_input += num_block_output * stride_input;
 
         if i - 1u == dim_cat {
@@ -41,8 +42,6 @@ fn main(
         }
     }
 
-    if num_elem_input < global_id.x {
-        output[index_output] = input[index_input];
-    }
+    output[index_output] = input[index_input];
 }
 


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [X] Confirm that `run-checks.sh` has been executed.

### Changes

Tensors can have 65536 * 65536 * 1024 elements vs 65536 * 1024 before.

### Testing

Add two tests