### PR TITLE
Add Tensor as a module constant

### DIFF
--- a/burn-core/src/module/base.rs
+++ b/burn-core/src/module/base.rs
@@ -107,6 +107,7 @@ pub trait Module<B: Backend>: Clone + Send + Sync + core::fmt::Debug {
             init = Vec::new
         )
     }
+
     /// Fork the module and all of its sub-modules to the given device.
     ///
     /// # Notes
@@ -129,6 +130,7 @@ pub trait Module<B: Backend>: Clone + Send + Sync + core::fmt::Debug {
             capture = { device: B::Device }
         )
     }
+
     /// Move the module and all of its sub-modules to the given device.
     ///
     /// # Warnings
@@ -143,6 +145,7 @@ pub trait Module<B: Backend>: Clone + Send + Sync + core::fmt::Debug {
             capture = { device: B::Device }
         )
     }
+
     /// Each tensor in the module tree will not require grad.
     ///
     /// # Warnings
@@ -170,10 +173,13 @@ pub trait Module<B: Backend>: Clone + Send + Sync + core::fmt::Debug {
     }
     /// Visit each tensor in the module with a [visitor](ModuleVisitor).
     fn visit<V: ModuleVisitor<B>>(&self, visitor: &mut V);
+
     /// Map each tensor in the module with a [mapper](ModuleMapper).
     fn map<M: ModuleMapper<B>>(self, mapper: &mut M) -> Self;
     /// Load the module state from a record.
+
     fn load_record(self, record: Self::Record) -> Self;
+
     /// Convert the module into a record containing the state.
     fn into_record(self) -> Self::Record;
 }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirm that `run-checks.sh` has been executed.

### Changes

Previously it was not possible to add a tensor attribute to a module struct. Now this is possible:

```rust
// Define the model structure
#[derive(Module, Debug)]
pub struct ClassificationModel<B: Backend> {
    transformer: TransformerEncoder<B>,
    embedding_pos: Embedding<B>,
    layer_norm: LayerNorm<B>,
    output: Linear<B>,
    n_classes: usize,
    max_seq_length: usize,
    sinusoids: Tensor<B, 2>, // <-- Tensor works now
}

```

### Testing

Unit testing and manually verifying exported module like the following:

```rust
fn main() {
    let trans_encoder = TransformerEncoderConfig::new(64, 512, 8, 4)
        .with_norm_first(false)
        .with_dropout(0.25);

    type TestBackend = NdArrayBackend<f32>;
    let model = ClassificationModelConfig::new(trans_encoder, 10, 64, 87).init::<TestBackend>();

    let recorder = PrettyJsonFileRecorder::<FullPrecisionSettings>::default();

    recorder
        .record(model.clone().into_record(), "model.json".into())
        .unwrap();
}
```
