### PR TITLE
Update plot rendering from textplots-rs to termplot

### DIFF
--- a/burn-train/Cargo.toml
+++ b/burn-train/Cargo.toml
@@ -22,7 +22,7 @@ log4rs = {workspace = true}
 nvml-wrapper = "0.9.0"
 rgb = "0.8.36"
 terminal_size = "0.2.6"
-textplots = "0.8.0"
+termplot = "0.1.0"
 
 # Utilities
 derive-new = {workspace = true}

--- a/burn-train/src/metric/dashboard/plot.rs
+++ b/burn-train/src/metric/dashboard/plot.rs
@@ -172,10 +172,13 @@ impl TextPlot {
         };
 
         plot.set_domain(Domain(x_min..x_max))
-            .set_codomain(Domain(0.0..100.0))
+            .set_codomain(Domain(0.0..200.0))
             .set_size(Size::new(width, height))
             .add_plot(Box::new(plot::Graph::new(train_plot)))
             .add_plot(Box::new(plot::Graph::new(valid_plot)))
+            .set_title("Training Metrics")
+            .set_x_label("X-Axis: Iterations")
+            .set_y_label("Y-Axis: Accuracy")
             .to_string()
     }
 }

--- a/burn-train/src/metric/dashboard/plot.rs
+++ b/burn-train/src/metric/dashboard/plot.rs
@@ -1,6 +1,6 @@
 use rgb::RGB8;
 use terminal_size::{terminal_size, Height, Width};
-use textplots::{Chart, ColorPlot, Shape};
+use termplot::{Plot, Domain, Size, plot};
 
 /// Text plot.
 pub struct TextPlot {
@@ -137,13 +137,26 @@ impl TextPlot {
         let x_min = f32::min(x_min_train, x_min_valid);
 
         let (width, height) = match terminal_size() {
-            Some((Width(w), Height(_))) => (u32::max(64, w.into()) * 2 - 16, 64),
+            Some((Width(w), Height(_))) => (usize::max(64, w.into()) * 2 - 16, 64),
             None => (256, 64),
         };
 
-        Chart::new(width, height, x_min, x_max)
+        let mut plot = Plot::default();
+
+        plot.set_domain(Domain(0.0..x_min.into()))
+        .set_codomain(Domain(0.0..x_max.into()))
+        .set_size(Size::new(width, height))
+        .add_plot()
+        .add_plot()
+        .to_string()
+        
+
+        /* 
+
+        Plot::new(width, height, x_min, x_max)
             .linecolorplot(&Shape::Lines(&self.train), train_color)
             .linecolorplot(&Shape::Lines(&self.valid), valid_color)
             .to_string()
+            */
     }
 }

--- a/burn-train/src/metric/dashboard/plot.rs
+++ b/burn-train/src/metric/dashboard/plot.rs
@@ -1,4 +1,3 @@
-use rgb::RGB8;
 use terminal_size::{terminal_size, Height, Width};
 use termplot::{plot, Domain, Plot, Size};
 
@@ -147,6 +146,10 @@ impl TextPlot {
         let x_max = f64::from(x_max);
 
         let train_plot = move |x: f64| -> f64 {
+            if train_values.is_empty() {
+                return 0.0;
+            }
+
             let index = {
                 let x_min = x_min;
                 let x_max = x_max;
@@ -156,6 +159,10 @@ impl TextPlot {
         };
 
         let valid_plot = move |x: f64| -> f64 {
+            if valid_values.is_empty() {
+                return 0.0;
+            }
+
             let index = {
                 let x_min = x_min;
                 let x_max = x_max;
@@ -165,7 +172,7 @@ impl TextPlot {
         };
 
         plot.set_domain(Domain(x_min..x_max))
-            .set_codomain(Domain(0.0..10.0))
+            .set_codomain(Domain(0.0..100.0))
             .set_size(Size::new(width, height))
             .add_plot(Box::new(plot::Graph::new(train_plot)))
             .add_plot(Box::new(plot::Graph::new(valid_plot)))

--- a/burn-train/src/metric/dashboard/plot.rs
+++ b/burn-train/src/metric/dashboard/plot.rs
@@ -109,9 +109,6 @@ impl TextPlot {
     ///
     /// The rendered text plot.
     pub fn render(&self) -> String {
-        let train_color = RGB8::new(255, 140, 140);
-        let valid_color = RGB8::new(140, 140, 255);
-
         let x_max_valid = self
             .valid
             .last()
@@ -173,13 +170,5 @@ impl TextPlot {
             .add_plot(Box::new(plot::Graph::new(train_plot)))
             .add_plot(Box::new(plot::Graph::new(valid_plot)))
             .to_string()
-
-        /*
-
-        Plot::new(width, height, x_min, x_max)
-            .linecolorplot(&Shape::Lines(&self.train), train_color)
-            .linecolorplot(&Shape::Lines(&self.valid), valid_color)
-            .to_string()
-            */
     }
 }

--- a/burn-train/src/metric/dashboard/plot.rs
+++ b/burn-train/src/metric/dashboard/plot.rs
@@ -1,6 +1,6 @@
 use rgb::RGB8;
 use terminal_size::{terminal_size, Height, Width};
-use termplot::{Plot, Domain, Size, plot};
+use termplot::{plot, Domain, Plot, Size};
 
 /// Text plot.
 pub struct TextPlot {
@@ -143,15 +143,38 @@ impl TextPlot {
 
         let mut plot = Plot::default();
 
-        plot.set_domain(Domain(0.0..x_min.into()))
-        .set_codomain(Domain(0.0..x_max.into()))
-        .set_size(Size::new(width, height))
-        .add_plot()
-        .add_plot()
-        .to_string()
-        
+        let train_values: Vec<f64> = self.train.iter().map(|(x, _)| f64::from(*x)).collect();
+        let valid_values: Vec<f64> = self.valid.iter().map(|(x, _)| f64::from(*x)).collect();
 
-        /* 
+        let x_min = f64::from(x_min);
+        let x_max = f64::from(x_max);
+
+        let train_plot = move |x: f64| -> f64 {
+            let index = {
+                let x_min = x_min;
+                let x_max = x_max;
+                (x - x_min) / (x_max - x_min) * (train_values.len() - 1) as f64
+            };
+            train_values[index as usize]
+        };
+
+        let valid_plot = move |x: f64| -> f64 {
+            let index = {
+                let x_min = x_min;
+                let x_max = x_max;
+                (x - x_min) / (x_max - x_min) * (valid_values.len() - 1) as f64
+            };
+            valid_values[index as usize]
+        };
+
+        plot.set_domain(Domain(x_min..x_max))
+            .set_codomain(Domain(0.0..10.0))
+            .set_size(Size::new(width, height))
+            .add_plot(Box::new(plot::Graph::new(train_plot)))
+            .add_plot(Box::new(plot::Graph::new(valid_plot)))
+            .to_string()
+
+        /*
 
         Plot::new(width, height, x_min, x_max)
             .linecolorplot(&Shape::Lines(&self.train), train_color)

--- a/burn-train/src/metric/dashboard/plot.rs
+++ b/burn-train/src/metric/dashboard/plot.rs
@@ -139,43 +139,43 @@ impl TextPlot {
 
         let mut plot = Plot::default();
 
-        let train_values: Vec<f64> = self.train.iter().map(|(x, _)| f64::from(*x)).collect();
-        let valid_values: Vec<f64> = self.valid.iter().map(|(x, _)| f64::from(*x)).collect();
+        let train_data: Vec<(f64, f64)> = self
+            .train
+            .iter()
+            .map(|&(x, y)| (f64::from(x), f64::from(y)))
+            .collect();
+        let valid_data: Vec<(f64, f64)> = self
+            .valid
+            .iter()
+            .map(|&(x, y)| (f64::from(x), f64::from(y)))
+            .collect();
 
         let x_min = f64::from(x_min);
         let x_max = f64::from(x_max);
 
-        let train_plot = move |x: f64| -> f64 {
-            if train_values.is_empty() {
+        let train_graph = plot::Graph::new(Box::new(move |x: f64| -> f64 {
+            if train_data.is_empty() {
                 return 0.0;
             }
 
-            let index = {
-                let x_min = x_min;
-                let x_max = x_max;
-                (x - x_min) / (x_max - x_min) * (train_values.len() - 1) as f64
-            };
-            train_values[index as usize]
-        };
+            let index = ((x - x_min) / (x_max - x_min) * (train_data.len() - 1) as f64) as usize;
+            train_data[index].1
+        }));
 
-        let valid_plot = move |x: f64| -> f64 {
-            if valid_values.is_empty() {
+        let valid_graph = plot::Graph::new(Box::new(move |x: f64| -> f64 {
+            if valid_data.is_empty() {
                 return 0.0;
             }
 
-            let index = {
-                let x_min = x_min;
-                let x_max = x_max;
-                (x - x_min) / (x_max - x_min) * (valid_values.len() - 1) as f64
-            };
-            valid_values[index as usize]
-        };
+            let index = ((x - x_min) / (x_max - x_min) * (valid_data.len() - 1) as f64) as usize;
+            valid_data[index].1
+        }));
 
         plot.set_domain(Domain(x_min..x_max))
-            .set_codomain(Domain(0.0..200.0))
+            .set_codomain(Domain(0.0..100.0))
             .set_size(Size::new(width, height))
-            .add_plot(Box::new(plot::Graph::new(train_plot)))
-            .add_plot(Box::new(plot::Graph::new(valid_plot)))
+            .add_plot(Box::new(train_graph))
+            .add_plot(Box::new(valid_graph))
             .set_title("Training Metrics")
             .set_x_label("X-Axis: Iterations")
             .set_y_label("Y-Axis: Accuracy")


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [X] Confirm that `run-checks.sh` has been executed.

### Related Issues/PRs

This solves issue here: https://github.com/burn-rs/burn/issues/211

### Changes

Rendering of plots relied on `textplot-rs` which has a couple of issues:

1. The dots were not rendering correctly, causing a confusion in what the graph is showing.
2. `textplot-rts` has a dependency with `nom` which causes a compilation warning when building `burn`

The changes made reflect the requirements for using `termplot`. The main two changes made:

1. Coloring is not an option for `termplot` so all references to color have been removed.
2. `termplot` uses `f64` values instead of `f32` values which were previously used. Conversions have been made where necessary.
3. `width` variable was of type `u32` but has been changed to `usize` to match `height`. Use of `usize` is better practice in this case as well.
4. Syntax has been modified as needed to work with `termplot`.

### Testing

Testing has been done by rendering plots for training data such as `mnist` example.
