### PR TITLE
Fix intermittent test failure

### DIFF
--- a/burn-core/src/nn/embedding.rs
+++ b/burn-core/src/nn/embedding.rs
@@ -85,10 +85,10 @@ mod tests {
                 std: 1.0
             }
         );
-        var_act.to_data().assert_approx_eq(&Data::from([1.0f32]), 1);
+        var_act.to_data().assert_approx_eq(&Data::from([1.0f32]), 0);
         mean_act
             .to_data()
-            .assert_approx_eq(&Data::from([0.0f32]), 1);
+            .assert_approx_eq(&Data::from([0.0f32]), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirm that `run-checks.sh` has been executed.

### Changes

Fixes the following test failure:

```

failures:

---- nn::embedding::tests::initializer_default stdout ----
thread 'nn::embedding::tests::initializer_default' panicked at 'Tensors are not approx eq:
  => Position 0: 1.1058791875839233 != 1 | difference 0.10587918758392334 > tolerance 0.1', /Users/dilshod/Projects/burn/burn-tensor/src/tensor/data.rs:329:13


failures:
    nn::embedding::tests::initializer_default

test result: FAILED. 79 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.21s

error: test failed, to rerun pass `--lib`
```

### Testing

Ran `run-checks.sh`