### PR TITLE
Move main file into the bin directory for onnx_inference example

### DIFF
--- a/examples/onnx-inference/README.md
+++ b/examples/onnx-inference/README.md
@@ -34,10 +34,12 @@ https://datasets-server.huggingface.co/assets/mnist/--/mnist/test/15/image/image
        include!(concat!(env!("OUT_DIR"), "/model/mnist.rs"));
    }
    ```
-4. Add the module to lib.rs:
+4. Add the module to `lib.rs`:
 
    ```rust
    pub mod model;
+
+   pub use model::mnist::*;
    ```
 
 5. Add the following to `build.rs`:
@@ -55,23 +57,21 @@ https://datasets-server.huggingface.co/assets/mnist/--/mnist/test/15/image/image
 
    ```
 
-6. Run `cargo build` to generate the model code and weights.
-
-7. Use the model in your code (Sample code):
+6. Add your model to `src/bin` as a new file, in this specific case we have
+called it `mnist.rs`:
 
    ```rust
-   mod model;
-
    use burn::tensor;
    use burn_ndarray::NdArrayBackend;
-   use model::mnist::{Model, INPUT1_SHAPE};
+
+   use onnx_inference::mnist::Model;
 
    fn main() {
        // Create a new model and load the state
        let model: Model<Backend> = Model::new().load_state();
 
        // Create a new input tensor (all zeros for demonstration purposes)
-       let input = tensor::Tensor::<NdArrayBackend<f32>, 4>::zeros(INPUT1_SHAPE);
+       let input = tensor::Tensor::<NdArrayBackend<f32>, 4>::zeros([1, 1, 28, 28]);
 
        // Run the model
        let output = model.forward(input);
@@ -80,6 +80,8 @@ https://datasets-server.huggingface.co/assets/mnist/--/mnist/test/15/image/image
        println!("{:?}", output);
    }
    ```
+
+7. Run `cargo build` to generate the model code, weights, and `mnist` binary.
 
 ## How to export PyTorch model to ONNX
 

--- a/examples/onnx-inference/src/bin/mnist.rs
+++ b/examples/onnx-inference/src/bin/mnist.rs
@@ -1,13 +1,12 @@
-mod model;
-
 use std::env::args;
 
 use burn::tensor::Tensor;
 use burn_ndarray::NdArrayBackend;
-use model::mnist::Model;
 
 use burn_dataset::source::huggingface::MNISTDataset;
 use burn_dataset::Dataset;
+
+use onnx_inference::mnist::Model;
 
 const IMAGE_INX: usize = 42; // <- Change this to test a different image
 

--- a/examples/onnx-inference/src/lib.rs
+++ b/examples/onnx-inference/src/lib.rs
@@ -1,1 +1,3 @@
 pub mod model;
+
+pub use model::mnist;


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirm that `run-checks.sh` has been executed.

### Related Issues/PRs

_Provide links to relevant issues and dependent PRs._

### Changes

This PR moves the `main.rs` binary into the `bin` directory. Reasons:
- In this way `lib.rs` is not only a placeholder, but instead we show how library APIs are imported and used in a binary
- It is possible to add more models, for different neural networks, adding a new file into `src/bin` directory. Thus we improve the example modularity

### Testing

Run `cargo build` on the example