### PR TITLE
Add Sigmoid operator to burn-import

### DIFF
--- a/burn-import/README.md
+++ b/burn-import/README.md
@@ -16,6 +16,7 @@ still under development.
 - Gemm (Linear layer)
 - LogSoftmax
 - Relu
+- Sigmoid
 
 ## Usage
 

--- a/burn-import/src/burn/node/base.rs
+++ b/burn-import/src/burn/node/base.rs
@@ -1,7 +1,7 @@
 use super::{
     batch_norm::BatchNormNode, constant::ConstantNode, conv2d::Conv2dNode, equal::EqualNode,
     flatten::FlattenNode, linear::LinearNode, log_softmax::LogSoftmaxNode, matmul::MatmulNode,
-    relu::ReLUNode,
+    relu::ReLUNode, sigmoid::SigmoidNode,
 };
 use crate::burn::{BurnImports, Scope, Type};
 use burn::record::PrecisionSettings;
@@ -80,6 +80,7 @@ pub enum Node<PS: PrecisionSettings> {
     LogSoftmax(LogSoftmaxNode),
     Constant(ConstantNode),
     Equal(EqualNode),
+    Sigmoid(SigmoidNode),
 }
 
 macro_rules! match_all {
@@ -94,6 +95,7 @@ macro_rules! match_all {
             Node::LogSoftmax(node) => $func(node),
             Node::Constant(node) => $func(node),
             Node::Equal(node) => $func(node),
+            Node::Sigmoid(node) => $func(node),
         }
     }};
 }
@@ -119,6 +121,7 @@ impl<PS: PrecisionSettings> Node<PS> {
             Node::Flatten(_) => "flatten",
             Node::LogSoftmax(_) => "log_softmax",
             Node::Equal(_) => "equal",
+            Node::Sigmoid(_) => "sigmoid",
         }
     }
 }

--- a/burn-import/src/burn/node/mod.rs
+++ b/burn-import/src/burn/node/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod linear;
 pub(crate) mod log_softmax;
 pub(crate) mod matmul;
 pub(crate) mod relu;
+pub(crate) mod sigmoid;
 
 pub(crate) use base::*;
 

--- a/burn-import/src/burn/node/sigmoid.rs
+++ b/burn-import/src/burn/node/sigmoid.rs
@@ -1,0 +1,83 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+
+use burn::record::PrecisionSettings;
+
+use super::{Node, NodeCodegen};
+
+use crate::burn::{Scope, TensorType, Type};
+
+#[derive(Debug, Clone, new)]
+pub struct SigmoidNode {
+    pub input: TensorType,
+    pub output: TensorType,
+}
+
+impl<PS: PrecisionSettings> NodeCodegen<PS> for SigmoidNode {
+    fn output_types(&self) -> Vec<Type> {
+        vec![Type::Tensor(&self.output)]
+    }
+
+    fn input_types(&self) -> Vec<Type> {
+        vec![Type::Tensor(&self.input)]
+    }
+
+    fn forward(&self, scope: &mut Scope, node_position: usize) -> TokenStream {
+        let input = scope.tensor_use_owned(&self.input, node_position);
+        let output = &self.output.name;
+
+        quote! {
+            let #output = #input.sigmoid();
+        }
+    }
+
+    fn into_node(self) -> Node<PS> {
+        Node::Sigmoid(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use burn::record::FullPrecisionSettings;
+
+    use super::*;
+    use crate::burn::{
+        graph::BurnGraph,
+        node::{sigmoid::SigmoidNode, test::assert_tokens},
+        TensorType,
+    };
+
+    #[test]
+    fn test_codegen_nodes() {
+        let mut graph = BurnGraph::<FullPrecisionSettings>::default();
+
+        graph.register(SigmoidNode::new(
+            TensorType::new_float("tensor1", 4),
+            TensorType::new_float("tensor2", 4),
+        ));
+
+        let expected = quote! {
+            use burn::{
+                module::Module,
+                tensor::{backend::Backend, Tensor},
+            };
+
+            #[derive(Module, Debug)]
+            pub struct Model <B: Backend>{}
+
+            impl<B: Backend> Model <B> {
+                pub fn new_with(record: ModelRecord<B>) -> Self {
+                    Self { }
+                }
+                #[allow(clippy::let_and_return)]
+                pub fn forward(&self, tensor1: Tensor<B, 4>) -> Tensor<B, 4> {
+                    let tensor2 = tensor1.sigmoid();
+
+                    tensor2
+                }
+            }
+        };
+
+        assert_tokens(graph.codegen(), expected);
+    }
+}

--- a/burn-import/src/onnx/dim_inference.rs
+++ b/burn-import/src/onnx/dim_inference.rs
@@ -83,6 +83,7 @@ pub fn dim_inference(
             NodeType::Unsqueeze => unsqueeze_update_outputs(node),
             NodeType::Slice => slice_update_outputs(node),
             NodeType::MatMul => same_as_input(node),
+            NodeType::Sigmoid => same_as_input(node),
             NodeType::Concat => concat_update_outputs(node),
             NodeType::Reshape => reshape_update_outputs(node),
             _ => todo!(

--- a/burn-import/src/onnx/to_burn.rs
+++ b/burn-import/src/onnx/to_burn.rs
@@ -22,6 +22,7 @@ use crate::{
             log_softmax::LogSoftmaxNode,
             matmul::MatmulNode,
             relu::ReLUNode,
+            sigmoid::SigmoidNode,
         },
         TensorType,
     },
@@ -161,6 +162,7 @@ impl ONNXGraph {
                 NodeType::LogSoftmax => graph.register(Self::log_softmax_conversion(node)),
                 NodeType::Constant => graph.register(Self::constant_conversion(node)),
                 NodeType::Equal => graph.register(Self::equal_conversion(node)),
+                NodeType::Sigmoid => graph.register(Self::sigmoid_conversion(node)),
                 _ => panic!("Unsupported node conversion {}", node.node_type),
             }
         }
@@ -212,6 +214,13 @@ impl ONNXGraph {
         let (start_dim, end_dim) = flatten_config(&node);
 
         FlattenNode::new(input, output, start_dim, end_dim)
+    }
+
+    fn sigmoid_conversion(node: Node) -> SigmoidNode {
+        let input = node.inputs.get(0).unwrap().to_tensor_type();
+        let output = node.outputs.get(0).unwrap().to_tensor_type();
+
+        SigmoidNode::new(input, output)
     }
 
     fn log_softmax_conversion(node: Node) -> LogSoftmaxNode {


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ ] Confirm that `run-checks.sh` has been executed.

### Related Issues/PRs

_Provide links to relevant issues and dependent PRs._

### Changes

This PR adds Sigmoid operator to `burn-import` crate. I have also added a test to verify code generation starting from `MatMul` operator code, if it is not needed I can remove it. Thanks in advance for your review!

### Testing

Run `cargo build` and then `cargo test`. I also run `cargo r -- ./yolov5.onnx ./` to verify if the operator had been parsed.