### PR TITLE
Bugfix/matmul/asymetric shapes

### DIFF
--- a/burn-wgpu/src/kernel/matmul/tiling2d/base.rs
+++ b/burn-wgpu/src/kernel/matmul/tiling2d/base.rs
@@ -155,6 +155,16 @@ macro_rules! matmul_tile_2d {
             }
 
             #[test]
+            pub fn test_matmul_tiling_2d_m_larger_than_n() {
+                test_with_params::<64, 64, 32, 4, 4, 16, 16>(64, 32, 4, 1, 1);
+            }
+
+            #[test]
+            pub fn test_matmul_tiling_2d_n_larger_than_m() {
+                test_with_params::<64, 64, 32, 4, 4, 16, 16>(4, 32, 64, 1, 1);
+            }
+
+            #[test]
             pub fn test_matmul_tiling_2d_shapes_smaller_than_blocks() {
                 test_with_params::<64, 64, 8, 4, 4, 16, 16>(8, 8, 8, 1, 1);
             }
@@ -396,10 +406,16 @@ pub(super) fn matmul_tiling_2d_launch<
         &rhs,
     );
 
+    println!("{lhs:?}");
+    println!("{rhs:?}");
+
     let final_output_shape = shape_out(&lhs, &rhs);
     let lhs = pad_round(lhs, B_M, B_K);
     let rhs = pad_round(rhs, B_K, B_N);
     let rounded_output_shape = shape_out(&lhs, &rhs);
+
+    println!("{lhs:?}");
+    println!("{rhs:?}");
 
     let output = empty_from_context::<E, D>(rhs.context.clone(), &rounded_output_shape);
 

--- a/burn-wgpu/src/kernel/matmul/tiling2d/base.rs
+++ b/burn-wgpu/src/kernel/matmul/tiling2d/base.rs
@@ -406,16 +406,10 @@ pub(super) fn matmul_tiling_2d_launch<
         &rhs,
     );
 
-    println!("{lhs:?}");
-    println!("{rhs:?}");
-
     let final_output_shape = shape_out(&lhs, &rhs);
     let lhs = pad_round(lhs, B_M, B_K);
     let rhs = pad_round(rhs, B_K, B_N);
     let rounded_output_shape = shape_out(&lhs, &rhs);
-
-    println!("{lhs:?}");
-    println!("{rhs:?}");
 
     let output = empty_from_context::<E, D>(rhs.context.clone(), &rounded_output_shape);
 

--- a/burn-wgpu/src/kernel/matmul/tiling2d/padding.rs
+++ b/burn-wgpu/src/kernel/matmul/tiling2d/padding.rs
@@ -30,6 +30,10 @@ pub(super) fn pad_round<E: WgpuElement, const D: usize>(
     }
     padded_shape.push(tensor.shape.dims[D - 2] - row_modulo + row_divisor);
     padded_shape.push(tensor.shape.dims[D - 1] - col_modulo + col_divisor);
+    let x = tensor.shape.dims[D - 2] - row_modulo + row_divisor;
+    let y = tensor.shape.dims[D - 1] - col_modulo + col_divisor;
+    println!("{x}");
+    println!("{y}");
     padding::<E, D>(tensor, padded_shape.into())
 }
 
@@ -166,6 +170,34 @@ mod tests {
         let col_divisor = 5;
         let tensor = TestTensor::random([2, 3, row, col], burn_tensor::Distribution::Default);
         let expected_shape = [2, 3, 12, 15].into();
+
+        let padded = pad_round(tensor.into_primitive(), row_divisor, col_divisor);
+
+        assert!(padded.shape == expected_shape);
+    }
+
+    #[test]
+    fn padding_with_row_divisor_larger_than_row() {
+        let row = 10;
+        let row_divisor = 32;
+        let col = 4;
+        let col_divisor = 3;
+        let tensor = TestTensor::random([row, col], burn_tensor::Distribution::Default);
+        let expected_shape = [row, col].into();
+
+        let padded = pad_round(tensor.into_primitive(), row_divisor, col_divisor);
+
+        assert!(padded.shape == expected_shape);
+    }
+
+    #[test]
+    fn padding_with_col_divisor_larger_than_col() {
+        let row = 32;
+        let row_divisor = 32;
+        let col = 4;
+        let col_divisor = 64;
+        let tensor = TestTensor::random([row, col], burn_tensor::Distribution::Default);
+        let expected_shape = [row, col].into();
 
         let padded = pad_round(tensor.into_primitive(), row_divisor, col_divisor);
 

--- a/burn-wgpu/src/kernel/matmul/tiling2d/padding.rs
+++ b/burn-wgpu/src/kernel/matmul/tiling2d/padding.rs
@@ -19,21 +19,30 @@ pub(super) fn pad_round<E: WgpuElement, const D: usize>(
     row_divisor: usize,
     col_divisor: usize,
 ) -> WgpuTensor<E, D> {
-    let row_modulo = tensor.shape.dims[D - 2] % row_divisor;
-    let col_modulo = tensor.shape.dims[D - 1] % col_divisor;
-    if row_modulo == 0 && col_modulo == 0 {
+    let previous_row_dim = tensor.shape.dims[D - 2];
+    let previous_col_dim = tensor.shape.dims[D - 1];
+    let row_modulo = previous_row_dim % row_divisor;
+    let col_modulo = previous_col_dim % col_divisor;
+
+    let new_row_dim = match row_modulo {
+        0 => previous_row_dim,
+        _ => previous_row_dim + row_divisor - row_modulo,
+    };
+    let new_col_dim = match col_modulo {
+        0 => previous_col_dim,
+        _ => previous_col_dim + col_divisor - col_modulo,
+    };
+    if previous_row_dim == new_row_dim && previous_col_dim == new_col_dim {
         return tensor;
     }
+
     let mut padded_shape = Vec::with_capacity(D);
     for i in 0..D - 2 {
         padded_shape.push(tensor.shape.dims[i]);
     }
-    padded_shape.push(tensor.shape.dims[D - 2] - row_modulo + row_divisor);
-    padded_shape.push(tensor.shape.dims[D - 1] - col_modulo + col_divisor);
-    let x = tensor.shape.dims[D - 2] - row_modulo + row_divisor;
-    let y = tensor.shape.dims[D - 1] - col_modulo + col_divisor;
-    println!("{x}");
-    println!("{y}");
+    padded_shape.push(new_row_dim);
+    padded_shape.push(new_col_dim);
+
     padding::<E, D>(tensor, padded_shape.into())
 }
 
@@ -183,7 +192,7 @@ mod tests {
         let col = 4;
         let col_divisor = 3;
         let tensor = TestTensor::random([row, col], burn_tensor::Distribution::Default);
-        let expected_shape = [row, col].into();
+        let expected_shape = [row_divisor, 2 * col_divisor].into();
 
         let padded = pad_round(tensor.into_primitive(), row_divisor, col_divisor);
 
@@ -191,13 +200,13 @@ mod tests {
     }
 
     #[test]
-    fn padding_with_col_divisor_larger_than_col() {
+    fn padding_with_row_divisor_equal_to_row_but_col_must_be_padded() {
         let row = 32;
         let row_divisor = 32;
         let col = 4;
         let col_divisor = 64;
         let tensor = TestTensor::random([row, col], burn_tensor::Distribution::Default);
-        let expected_shape = [row, col].into();
+        let expected_shape = [32, 64].into();
 
         let padded = pad_round(tensor.into_primitive(), row_divisor, col_divisor);
 

--- a/burn-wgpu/src/template/matmul/blocktiling_2d/continuous.wgsl
+++ b/burn-wgpu/src/template/matmul/blocktiling_2d/continuous.wgsl
@@ -131,9 +131,9 @@ fn main(
             let current_row = row + res_idx_M;
             let current_col = col + res_idx_N;
             // Check that we are within the bounds of output matrix
-                let result_position = res_idx_M * T_N + res_idx_N;
-                let output_position = offset_output + current_row * n_cols + current_col;
-                output[output_position] = results[result_position];
+            let result_position = res_idx_M * T_N + res_idx_N;
+            let output_position = offset_output + current_row * n_cols + current_col;
+            output[output_position] = results[result_position];
         }
     }
 }

--- a/burn-wgpu/src/template/matmul/blocktiling_2d/continuous_vectorized.wgsl
+++ b/burn-wgpu/src/template/matmul/blocktiling_2d/continuous_vectorized.wgsl
@@ -131,7 +131,7 @@ fn main(
     for (var res_idx_M = 0u; res_idx_M < T_M; res_idx_M++) {
         for (var res_idx_N = 0u; res_idx_N < T_N; res_idx_N++) {
             let result_position = res_idx_M * T_N + res_idx_N;
-            let output_position = offset_output + (row + res_idx_M) * n_cols + col + res_idx_N;;
+            let output_position = offset_output + (row + res_idx_M) * n_cols + col + res_idx_N;
             output[output_position] = results[result_position];
         }
     }

--- a/burn-wgpu/src/template/matmul/blocktiling_2d/tile.wgsl
+++ b/burn-wgpu/src/template/matmul/blocktiling_2d/tile.wgsl
@@ -36,9 +36,9 @@ fn main(
     let skip_row = workgroup_id.x * B_M;
     let skip_col = workgroup_id.y * B_N;
 
-    let n_thread_per_row = ((B_N - 1u) / T_N) + 1u;
-    let thread_row = (local_idx / n_thread_per_row) * T_M;
-    let thread_col = (local_idx % n_thread_per_row) * T_N;
+    let n_thread_per_row = ((B_N - 1u) / T_N) + 1u; // 16
+    let thread_row = (local_idx / n_thread_per_row) * T_M; // 16 premiers: 0, 16 suivants: 4, etc.
+    let thread_col = (local_idx % n_thread_per_row) * T_N; // 0,4,8,..,60. à répétition
     
     let row = skip_row + thread_row;
     let col = skip_col + thread_col;
@@ -133,8 +133,10 @@ fn main(
     for (var res_idx_M = 0u; res_idx_M < T_M; res_idx_M++) {
         for (var res_idx_N = 0u; res_idx_N < T_N; res_idx_N++) {
             let result_position = res_idx_M * T_N + res_idx_N;
-            let output_position = offset_output + (row + res_idx_M) * n_cols + col + res_idx_N;;
+            let output_position = offset_output + (row + res_idx_M) * n_cols + col + res_idx_N;
             output[output_position] = results[result_position];
         }
     }
+    // let output_position = offset_output + (row) * n_cols + col;
+    // output[output_position] = results[0u];
 }

--- a/burn-wgpu/src/template/matmul/blocktiling_2d/tile.wgsl
+++ b/burn-wgpu/src/template/matmul/blocktiling_2d/tile.wgsl
@@ -36,9 +36,9 @@ fn main(
     let skip_row = workgroup_id.x * B_M;
     let skip_col = workgroup_id.y * B_N;
 
-    let n_thread_per_row = ((B_N - 1u) / T_N) + 1u; // 16
-    let thread_row = (local_idx / n_thread_per_row) * T_M; // 16 premiers: 0, 16 suivants: 4, etc.
-    let thread_col = (local_idx % n_thread_per_row) * T_N; // 0,4,8,..,60. à répétition
+    let n_thread_per_row = ((B_N - 1u) / T_N) + 1u;
+    let thread_row = (local_idx / n_thread_per_row) * T_M;
+    let thread_col = (local_idx % n_thread_per_row) * T_N;
     
     let row = skip_row + thread_row;
     let col = skip_col + thread_col;
@@ -137,6 +137,4 @@ fn main(
             output[output_position] = results[result_position];
         }
     }
-    // let output_position = offset_output + (row) * n_cols + col;
-    // output[output_position] = results[0u];
 }

--- a/burn-wgpu/src/template/matmul/blocktiling_2d/tile_vectorized.wgsl
+++ b/burn-wgpu/src/template/matmul/blocktiling_2d/tile_vectorized.wgsl
@@ -133,7 +133,7 @@ fn main(
     for (var res_idx_M = 0u; res_idx_M < T_M; res_idx_M++) {
         for (var res_idx_N = 0u; res_idx_N < T_N; res_idx_N++) {
             let result_position = res_idx_M * T_N + res_idx_N;
-            let output_position = offset_output + (row + res_idx_M) * n_cols + col + res_idx_N;;
+            let output_position = offset_output + (row + res_idx_M) * n_cols + col + res_idx_N;
             output[output_position] = results[result_position];
         }
     }


### PR DESCRIPTION
### Checklist

- [x] Confirm that `run-checks.sh` has been executed.

### Changes

There were some cases in which matmul tiling 2d failed. Those are addressed by the two new matmul tests. 
The bug was in fact in padding, where, when only one of row and col dimensions was already "round", it would be rounded yet again to the higher multiple of the divisor. 

### Testing

New tests in padding and matmul