### PR TITLE
Allow for more flexible Data creation via From by adding traits that have the first dimension as non-const

### DIFF
--- a/burn-tensor/src/tensor/data.rs
+++ b/burn-tensor/src/tensor/data.rs
@@ -385,59 +385,57 @@ impl<E: core::fmt::Debug + Copy> From<&[E]> for Data<E, 1> {
     }
 }
 
-impl<E: core::fmt::Debug + Copy, const A: usize, const B: usize> From<[[E; B]; A]> for Data<E, 2> {
-    fn from(elems: [[E; B]; A]) -> Self {
-        let mut data = Vec::with_capacity(A * B);
-        for elem in elems.into_iter().take(A) {
-            for elem in elem.into_iter().take(B) {
-                data.push(elem);
+impl<E: core::fmt::Debug + Copy, const A: usize> From<&[[E; A]]> for Data<E, 2> {
+    fn from(elems: &[[E; A]]) -> Self {
+        let first_dim = elems.len();
+        let mut data = Vec::with_capacity(first_dim * A);
+        for elem in elems {
+            for elem in elem.iter().take(A) {
+                data.push(*elem);
             }
         }
 
-        Data::new(data, Shape::new([A, B]))
+        Data::new(data, Shape::new([first_dim, A]))
     }
 }
 
-impl<E: core::fmt::Debug + Copy, const A: usize, const B: usize, const C: usize>
-    From<[[[E; C]; B]; A]> for Data<E, 3>
+impl<E: core::fmt::Debug + Copy, const A: usize, const B: usize> From<&[[[E; B]; A]]>
+    for Data<E, 3>
 {
-    fn from(elems: [[[E; C]; B]; A]) -> Self {
-        let mut data = Vec::with_capacity(A * B * C);
+    fn from(elems: &[[[E; B]; A]]) -> Self {
+        let first_dim = elems.len();
+        let mut data = Vec::with_capacity(first_dim * A * B);
 
-        for elem in elems.into_iter().take(A) {
-            for elem in elem.into_iter().take(B) {
-                for elem in elem.into_iter().take(C) {
-                    data.push(elem);
+        for elem in elems {
+            for elem in elem.iter().take(A) {
+                for elem in elem.iter().take(B) {
+                    data.push(*elem);
                 }
             }
         }
 
-        Data::new(data, Shape::new([A, B, C]))
+        Data::new(data, Shape::new([first_dim, A, B]))
     }
 }
 
-impl<
-        E: core::fmt::Debug + Copy,
-        const A: usize,
-        const B: usize,
-        const C: usize,
-        const D: usize,
-    > From<[[[[E; D]; C]; B]; A]> for Data<E, 4>
+impl<E: core::fmt::Debug + Copy, const A: usize, const B: usize, const C: usize>
+    From<&[[[[E; C]; B]; A]]> for Data<E, 4>
 {
-    fn from(elems: [[[[E; D]; C]; B]; A]) -> Self {
-        let mut data = Vec::with_capacity(A * B * C * D);
+    fn from(elems: &[[[[E; C]; B]; A]]) -> Self {
+        let first_dim = elems.len();
+        let mut data = Vec::with_capacity(first_dim * A * B * C);
 
-        for elem in elems.into_iter().take(A) {
-            for elem in elem.into_iter().take(B) {
-                for elem in elem.into_iter().take(C) {
-                    for elem in elem.into_iter().take(D) {
-                        data.push(elem);
+        for elem in elems {
+            for elem in elem.iter().take(A) {
+                for elem in elem.iter().take(B) {
+                    for elem in elem.iter().take(C) {
+                        data.push(*elem);
                     }
                 }
             }
         }
 
-        Data::new(data, Shape::new([A, B, C, D]))
+        Data::new(data, Shape::new([first_dim, A, B, C]))
     }
 }
 

--- a/burn-tensor/src/tensor/data.rs
+++ b/burn-tensor/src/tensor/data.rs
@@ -374,6 +374,62 @@ impl<E: core::fmt::Debug + Copy, const A: usize> From<[E; A]> for Data<E, 1> {
     }
 }
 
+impl<E: core::fmt::Debug + Copy, const A: usize, const B: usize> From<[[E; B]; A]> for Data<E, 2> {
+    fn from(elems: [[E; B]; A]) -> Self {
+        let mut data = Vec::with_capacity(A * B);
+        for elem in elems.into_iter().take(A) {
+            for elem in elem.into_iter().take(B) {
+                data.push(elem);
+            }
+        }
+
+        Data::new(data, Shape::new([A, B]))
+    }
+}
+
+impl<E: core::fmt::Debug + Copy, const A: usize, const B: usize, const C: usize>
+    From<[[[E; C]; B]; A]> for Data<E, 3>
+{
+    fn from(elems: [[[E; C]; B]; A]) -> Self {
+        let mut data = Vec::with_capacity(A * B * C);
+
+        for elem in elems.into_iter().take(A) {
+            for elem in elem.into_iter().take(B) {
+                for elem in elem.into_iter().take(C) {
+                    data.push(elem);
+                }
+            }
+        }
+
+        Data::new(data, Shape::new([A, B, C]))
+    }
+}
+
+impl<
+        E: core::fmt::Debug + Copy,
+        const A: usize,
+        const B: usize,
+        const C: usize,
+        const D: usize,
+    > From<[[[[E; D]; C]; B]; A]> for Data<E, 4>
+{
+    fn from(elems: [[[[E; D]; C]; B]; A]) -> Self {
+        let mut data = Vec::with_capacity(A * B * C * D);
+
+        for elem in elems.into_iter().take(A) {
+            for elem in elem.into_iter().take(B) {
+                for elem in elem.into_iter().take(C) {
+                    for elem in elem.into_iter().take(D) {
+                        data.push(elem);
+                    }
+                }
+            }
+        }
+
+        Data::new(data, Shape::new([A, B, C, D]))
+    }
+}
+
 impl<E: core::fmt::Debug + Copy> From<&[E]> for Data<E, 1> {
     fn from(elems: &[E]) -> Self {
         let mut data = Vec::with_capacity(elems.len());


### PR DESCRIPTION
### Checklist

- [x] Confirm that `run-checks.sh` has been executed.

### Related Issues/PRs

The only relevant PR I can think of is #457, which generalizes on the work done here. However because the new traits added here aren't fallible I believe this would come out as a more welcome change.

### Changes

Sometimes one would like to for example, construct tensors from multidimensional data structures that don't have a const first dimension. Having a const first dimension isn't technically a requirement but yet only providing traits for non-const dimensions means losing the convenience of operating on `[[1, 2], [3, 4]` for example, as this isn't a borrow.

This PR seeks to add the support to do this for such use-cases without compromising others - this should be a SemVer minor change.

### Testing

Due to this PR only adding new traits not much testing was done besides using `run-checks.sh`.
