### PR TITLE
Add a `transpose` sugar: `tensor^T`

### DIFF
--- a/burn-tensor/src/tensor/api/base.rs
+++ b/burn-tensor/src/tensor/api/base.rs
@@ -405,6 +405,23 @@ where
     }
 }
 
+/// Transpose marker (zero-size type). Used to sugar the transpose of a tensor, e.g.
+/// ```rust
+/// use burn_tensor::backend::Backend;
+/// use burn_tensor::{Tensor, T};
+///
+/// fn example<B: Backend>() {
+///     let tensor = Tensor::<B, 2>::from_floats([[1.0, 2.0], [3.0, 4.0]]);
+///     let transposed = tensor^T;
+/// }
+/// ```
+pub struct T;
+
+impl<B: Backend, const D: usize> core::ops::BitXor<T> for Tensor<B, D> {
+    type Output = Self;
+    fn bitxor(self, _: T) -> Self::Output { self.transpose() }
+}
+
 /// Trait that list all operations that can be applied on all tensors.
 ///
 /// # Warnings

--- a/burn-tensor/src/tensor/api/base.rs
+++ b/burn-tensor/src/tensor/api/base.rs
@@ -419,7 +419,9 @@ pub struct T;
 
 impl<B: Backend, const D: usize> core::ops::BitXor<T> for Tensor<B, D> {
     type Output = Self;
-    fn bitxor(self, _: T) -> Self::Output { self.transpose() }
+    fn bitxor(self, _: T) -> Self::Output {
+        self.transpose()
+    }
 }
 
 /// Trait that list all operations that can be applied on all tensors.

--- a/burn-tensor/src/tensor/api/float.rs
+++ b/burn-tensor/src/tensor/api/float.rs
@@ -252,18 +252,6 @@ where
     }
 }
 
-/// Transpose marker (zero-size type). Used to sugar the transpose of a tensor, e.g.
-/// ```rust
-/// let tensor = Tensor::<B, 2>::from_floats([[1.0, 2.0], [3.0, 4.0]]);
-/// let transposed = tensor^T;
-/// ```
-pub struct T;
-
-impl<B: Backend, const D: usize> std::ops::BitXor<T> for Tensor<B, D> {
-    type Output = Self;
-    fn bitxor(self, _: T) -> Self::Output { self.transpose() }
-}
-
 impl<const D: usize, B: ADBackend> Tensor<B, D> {
     /// Backward pass of the tensor.
     pub fn backward(&self) -> B::Gradients {

--- a/burn-tensor/src/tensor/api/float.rs
+++ b/burn-tensor/src/tensor/api/float.rs
@@ -252,6 +252,18 @@ where
     }
 }
 
+/// Transpose marker (zero-size type). Used to sugar the transpose of a tensor, e.g.
+/// ```rust
+/// let tensor = Tensor::<B, 2>::from_floats([[1.0, 2.0], [3.0, 4.0]]);
+/// let transposed = tensor^T;
+/// ```
+pub struct T;
+
+impl<B: Backend, const D: usize> std::ops::BitXor<T> for Tensor<B, D> {
+    type Output = Self;
+    fn bitxor(self, _: T) -> Self::Output { self.transpose() }
+}
+
 impl<const D: usize, B: ADBackend> Tensor<B, D> {
     /// Backward pass of the tensor.
     pub fn backward(&self) -> B::Gradients {


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirm that `run-checks.sh` has been executed.

`run-checks.rs` fails but with `burn-import` errors (I did not have anything to do with this).

### Related Issues/PRs
- https://github.com/burn-rs/burn/pull/509

### Changes

- zero-cost syntax sugar so we can write beautiful things like `tensor^T` to transpose a tensor.  This imitates the math notation for transposes and is a common pattern in tensor / linear algebra libraries.
- This defines a public zero-size-type `T`, for which we implement `core::ops::BitXor` to use the `^` caret operator.
- Does not interfere with any other present or future XOR ops or caret operator implementations.

### Testing

- it compiles, has no implementation to test, it defers to `self.transpose()`.
