### PR TITLE
burn-core: Use a specific structure for 1d padding

### DIFF
--- a/burn-core/src/nn/padding.rs
+++ b/burn-core/src/nn/padding.rs
@@ -5,6 +5,35 @@ use burn_tensor::ops::conv::calculate_conv_padding;
 use crate::config::Config;
 use crate::module::Module;
 
+/// Padding configuration for 1D operators.
+#[derive(Module, Config, Debug, PartialEq)]
+pub enum PaddingConfig1d {
+    /// Dynamically calculate the amount of padding necessary to ensure that the output size will be
+    /// the same as the input.
+    Same,
+    /// Same as no padding.
+    Valid,
+    /// Applies the specified amount of padding to all inputs.
+    Explicit(usize),
+}
+
+impl PaddingConfig1d {
+    pub(crate) fn calculate_padding_1d(
+        &self,
+        length: usize,
+        kernel_size: usize,
+        stride: usize,
+    ) -> usize {
+        let same_padding = || calculate_conv_padding(kernel_size, stride, length, length);
+
+        match self {
+            Self::Valid => 0,
+            Self::Same => same_padding(),
+            Self::Explicit(value) => *value,
+        }
+    }
+}
+
 /// Padding configuration for 2D operators.
 #[derive(Module, Config, Debug)]
 pub enum PaddingConfig2d {

--- a/burn-core/src/nn/pool/avg_pool1d.rs
+++ b/burn-core/src/nn/pool/avg_pool1d.rs
@@ -2,7 +2,7 @@ use crate as burn;
 
 use crate::config::Config;
 use crate::module::Module;
-use crate::nn::conv::Conv1dPaddingConfig;
+use crate::nn::PaddingConfig1d;
 use crate::tensor::backend::Backend;
 use crate::tensor::Tensor;
 use burn_tensor::module::avg_pool1d;
@@ -18,19 +18,16 @@ pub struct AvgPool1dConfig {
     #[config(default = "1")]
     pub stride: usize,
     /// The padding configuration.
-    #[config(default = "AvgPool1dPaddingConfig::Valid")]
-    pub padding: AvgPool1dPaddingConfig,
+    #[config(default = "PaddingConfig1d::Valid")]
+    pub padding: PaddingConfig1d,
 }
-
-/// Padding configuration for 1D avg pooling [config](AvgPool1dConfig).
-pub type AvgPool1dPaddingConfig = Conv1dPaddingConfig;
 
 /// Applies a 1D avg pooling over input tensors.
 #[derive(Module, Debug, Clone)]
 pub struct AvgPool1d {
     stride: usize,
     kernel_size: usize,
-    padding: AvgPool1dPaddingConfig,
+    padding: PaddingConfig1d,
 }
 
 impl AvgPool1dConfig {


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirm that `run-checks.sh` has been executed.

### Related Issues/PRs

_Provide links to relevant issues and dependent PRs._

### Changes

Use a new `PaddingConfig1d` struct shared with many operators. In this way we have a single implementation in a specific place without defining more types. It is possible to add new functions to this struct in order to support different padding implementation for new types of operator

### Testing

Run `cargo build` and `cargo test`
