### PR TITLE
Add functions to cast tensor to different kinds

### DIFF
--- a/burn-tensor/src/tensor/api/float.rs
+++ b/burn-tensor/src/tensor/api/float.rs
@@ -118,8 +118,8 @@ where
     ///     let int_tensor = float_tensor.int();
     /// }
     /// ```
-    pub fn int(&self) -> Tensor<B, D, Int> {
-        Tensor::<B, D, Int>::from_data(self.to_data().convert())
+    pub fn int(self) -> Tensor<B, D, Int> {
+        Tensor::<B, D, Int>::from_data(self.into_data().convert())
     }
 
     /// Returns a new tensor with the same shape and device as the current tensor filled with zeros.

--- a/burn-tensor/src/tensor/api/float.rs
+++ b/burn-tensor/src/tensor/api/float.rs
@@ -7,6 +7,7 @@ use crate::check::TensorCheck;
 use crate::tensor::backend::Backend;
 use crate::tensor::stats;
 use crate::tensor::{Data, Distribution, Shape};
+use crate::Int;
 use crate::Tensor;
 
 impl<const D: usize, B> Tensor<B, D>
@@ -101,6 +102,24 @@ where
     /// ```
     pub fn from_floats<A: Into<Data<f32, D>>>(floats: A) -> Self {
         Self::from_data(floats.into().convert())
+    }
+
+    /// Returns a new tensor with the same shape and device as the current tensor and the data
+    /// casted to Integer.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use burn_tensor::backend::Backend;
+    /// use burn_tensor::Tensor;
+    ///
+    /// fn example<B: Backend>() {
+    ///     let float_tensor = Tensor::<B, 1>::from_floats([1.0, 2.0]);
+    ///     let int_tensor = float_tensor.int();
+    /// }
+    /// ```
+    pub fn int(&self) -> Tensor<B, D, Int> {
+        Tensor::<B, D, Int>::from_data(self.to_data().convert())
     }
 
     /// Returns a new tensor with the same shape and device as the current tensor filled with zeros.

--- a/burn-tensor/src/tensor/api/int.rs
+++ b/burn-tensor/src/tensor/api/int.rs
@@ -1,4 +1,4 @@
-use crate::{backend::Backend, Data, Int, Tensor};
+use crate::{backend::Backend, Data, Float, Int, Tensor};
 use core::ops::Range;
 
 impl<B> Tensor<B, 1, Int>
@@ -64,5 +64,23 @@ where
     /// ```
     pub fn from_ints<A: Into<Data<i32, D>>>(ints: A) -> Self {
         Self::from_data(ints.into().convert())
+    }
+
+    /// Returns a new tensor with the same shape and device as the current tensor and the data
+    /// casted to Float.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use burn_tensor::backend::Backend;
+    /// use burn_tensor::{Int, Tensor};
+    ///
+    /// fn example<B: Backend>() {
+    ///     let int_tensor = Tensor::<B, 1, Int>::arange(0..5);
+    ///     let float_tensor = int_tensor.float();
+    /// }
+    /// ```
+    pub fn float(&self) -> Tensor<B, D, Float> {
+        Tensor::<B, D, Float>::from_data(self.to_data().convert())
     }
 }

--- a/burn-tensor/src/tensor/api/int.rs
+++ b/burn-tensor/src/tensor/api/int.rs
@@ -80,7 +80,7 @@ where
     ///     let float_tensor = int_tensor.float();
     /// }
     /// ```
-    pub fn float(&self) -> Tensor<B, D, Float> {
-        Tensor::<B, D, Float>::from_data(self.to_data().convert())
+    pub fn float(self) -> Tensor<B, D, Float> {
+        Tensor::<B, D, Float>::from_data(self.into_data().convert())
     }
 }

--- a/burn-tensor/src/tests/mod.rs
+++ b/burn-tensor/src/tests/mod.rs
@@ -30,6 +30,7 @@ macro_rules! testgen_all {
         burn_tensor::testgen_arange!();
         burn_tensor::testgen_arange_step!();
         burn_tensor::testgen_arg!();
+        burn_tensor::testgen_cast!();
         burn_tensor::testgen_cat!();
         burn_tensor::testgen_cos!();
         burn_tensor::testgen_div!();

--- a/burn-tensor/src/tests/ops/cast.rs
+++ b/burn-tensor/src/tests/ops/cast.rs
@@ -1,0 +1,25 @@
+#[burn_tensor_testgen::testgen(cast)]
+mod tests {
+    use super::*;
+    use burn_tensor::{Data, Int, Tensor};
+
+    #[test]
+    fn cast_float_tensor() {
+        let float_data = Data::from([[1.0, 2.0, 3.0], [4.4, 5.5, 6.6]]);
+        let float_tensor = Tensor::<TestBackend, 2>::from_data(float_data);
+
+        let int_tensor = float_tensor.int();
+        let data_expected = Data::from([[1, 2, 3], [4, 5, 6]]);
+        assert_eq!(data_expected, int_tensor.to_data());
+    }
+
+    #[test]
+    fn cast_int_tensor() {
+        let int_data = Data::from([[1, 2, 3], [4, 5, 6]]);
+        let int_tensor = Tensor::<TestBackend, 2, Int>::from_data(int_data);
+
+        let float_tensor = int_tensor.float();
+        let data_expected = Data::from([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+        assert_eq!(data_expected, float_tensor.to_data());
+    }
+}

--- a/burn-tensor/src/tests/ops/mod.rs
+++ b/burn-tensor/src/tests/ops/mod.rs
@@ -3,6 +3,7 @@ mod aggregation;
 mod arange;
 mod arange_step;
 mod arg;
+mod cast;
 mod cat;
 mod cos;
 mod div;


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirm that `run-checks.sh` has been executed.

### Related Issues/PRs

Related Issue: #487 

### Changes

1. Added `.int()` method to convert float tensors to integer kind.
2. Added `.float()` method to convert int tensors to float kind.

### Testing

Tested by manually creating and converting tensors.