### PR TITLE
Fix huggingface downloader Windows support (#564)

### DIFF
--- a/burn-dataset/src/source/huggingface/downloader.rs
+++ b/burn-dataset/src/source/huggingface/downloader.rs
@@ -10,6 +10,10 @@ use thiserror::Error;
 
 const PYTHON: &str = "python3";
 const PYTHON_SOURCE: &str = include_str!("importer.py");
+#[cfg(not(target_os = "windows"))]
+const VENV_BIN_PYTHON: &str = "bin/python3";
+#[cfg(target_os = "windows")]
+const VENV_BIN_PYTHON: &str = "Scripts\\python";
 
 /// Error type for [HuggingfaceDatasetLoader](HuggingfaceDatasetLoader).
 #[derive(Error, Debug)]
@@ -218,7 +222,7 @@ fn install_python_deps(base_dir: &Path) -> Result<PathBuf, ImporterError> {
         ImporterError::FailToDownloadPythonDependencies(format!(" error: {}", err))
     })?;
 
-    let venv_python_path = venv_dir.join("bin").join(PYTHON);
+    let venv_python_path = venv_dir.join(VENV_BIN_PYTHON);
 
     let mut command = Command::new(&venv_python_path);
     command.args([


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ ] Confirm that `run-checks.sh` has been executed. *(I'm not sure if this can be run on Windows. In the burn-dataset directory, I have manually tried "cargo test --all-features" which has the unrelated tests "dataset::sqlite::tests::sqlite_writer_write" and "dataset::sqlite::tests::sqlite_writer_write_multi_thread" fail, and tried "cargo doc --all-features" which works fine.)*

### Related Issues/PRs

https://github.com/burn-rs/burn/issues/564

### Changes

The path that the huggingface dataset downloader runs Python from has been changed to support how Python VirtualEnv arranges its files on Windows ([which is arbitrarily different](https://github.com/pypa/virtualenv/commit/993ba1316a83b760370f5a3872b3f5ef4dd904c1)).

### Testing

The commands `cargo run --example mnist --release --features ndarray` and `cargo run --example mnist --release --features wgpu` have been tested. They both now get past the download step and successfully start training with this PR's changes.
