### PR TITLE
Feat/conv transpose1d backward

### DIFF
--- a/burn-autodiff/src/tests/conv_transpose1d.rs
+++ b/burn-autodiff/src/tests/conv_transpose1d.rs
@@ -1,0 +1,257 @@
+#[burn_tensor_testgen::testgen(ad_conv_transpose1d)]
+mod tests {
+    use super::*;
+    use burn_tensor::{module::conv_transpose1d, ops::ConvTransposeOptions, Data, Shape};
+
+    #[test]
+    fn test_conv_transpose1d_basic() {
+        let test = ConvTranspose1dTestCase {
+            batch_size: 2,
+            channels: [2, 2],
+            kernel_size: 3,
+            padding: 0,
+            padding_out: 0,
+            stride: 1,
+            dilation: 1,
+            groups: 1,
+            size: 4,
+        };
+        let grads = Grads {
+            x: TestTensor::from_floats([
+                [[15.0, 15.0, 15.0, 15.0], [51.0, 51.0, 51.0, 51.0]],
+                [[15.0, 15.0, 15.0, 15.0], [51.0, 51.0, 51.0, 51.0]],
+            ]),
+            weight: TestTensor::from_floats([
+                [[44.0, 44.0, 44.0], [44.0, 44.0, 44.0]],
+                [[76.0, 76.0, 76.0], [76.0, 76.0, 76.0]],
+            ]),
+            bias: TestTensor::from_floats([12., 12.]),
+        };
+        test.assert_grads(grads);
+    }
+
+    #[test]
+    fn test_conv_transpose1d_padding() {
+        let test = ConvTranspose1dTestCase {
+            batch_size: 2,
+            channels: [2, 2],
+            kernel_size: 3,
+            padding: 2,
+            padding_out: 0,
+            stride: 1,
+            dilation: 1,
+            groups: 1,
+            size: 4,
+        };
+        let grads = Grads {
+            x: TestTensor::from_floats([
+                [[7., 12., 8., 3.], [19., 36., 32., 15.]],
+                [[7., 12., 8., 3.], [19., 36., 32., 15.]],
+            ]),
+            weight: TestTensor::from_floats([
+                [[26., 22., 18.], [26., 22., 18.]],
+                [[42., 38., 34.], [42., 38., 34.]],
+            ]),
+            bias: TestTensor::from_floats([4., 4.]),
+        };
+        test.assert_grads(grads);
+    }
+
+    #[test]
+    fn test_conv_transpose1d_stride() {
+        let test = ConvTranspose1dTestCase {
+            batch_size: 2,
+            channels: [2, 2],
+            kernel_size: 3,
+            padding: 0,
+            padding_out: 0,
+            stride: 2,
+            dilation: 1,
+            groups: 1,
+            size: 4,
+        };
+        let grads = Grads {
+            x: TestTensor::from_floats([
+                [[15., 15., 15., 15.], [51., 51., 51., 51.]],
+                [[15., 15., 15., 15.], [51., 51., 51., 51.]],
+            ]),
+            weight: TestTensor::from_floats([
+                [[44., 44., 44.], [44., 44., 44.]],
+                [[76., 76., 76.], [76., 76., 76.]],
+            ]),
+            bias: TestTensor::from_floats([18., 18.]),
+        };
+        test.assert_grads(grads);
+    }
+
+    #[test]
+    fn test_conv_transpose1d_stride_padding_out() {
+        let test = ConvTranspose1dTestCase {
+            batch_size: 2,
+            channels: [2, 2],
+            kernel_size: 3,
+            padding: 0,
+            padding_out: 1,
+            stride: 2,
+            dilation: 1,
+            groups: 1,
+            size: 4,
+        };
+        let grads = Grads {
+            x: TestTensor::from_floats([
+                [[15., 15., 15., 15.], [51., 51., 51., 51.]],
+                [[15., 15., 15., 15.], [51., 51., 51., 51.]],
+            ]),
+            weight: TestTensor::from_floats([
+                [[44., 44., 44.], [44., 44., 44.]],
+                [[76., 76., 76.], [76., 76., 76.]],
+            ]),
+            bias: TestTensor::from_floats([20., 20.]),
+        };
+        test.assert_grads(grads);
+    }
+
+    #[test]
+    fn test_conv_transpose1d_dilation() {
+        let test = ConvTranspose1dTestCase {
+            batch_size: 2,
+            channels: [2, 2],
+            kernel_size: 3,
+            padding: 0,
+            padding_out: 0,
+            stride: 1,
+            dilation: 2,
+            groups: 1,
+            size: 4,
+        };
+        let grads = Grads {
+            x: TestTensor::from_floats([
+                [[15., 15., 15., 15.], [51., 51., 51., 51.]],
+                [[15., 15., 15., 15.], [51., 51., 51., 51.]],
+            ]),
+            weight: TestTensor::from_floats([
+                [[44., 44., 44.], [44., 44., 44.]],
+                [[76., 76., 76.], [76., 76., 76.]],
+            ]),
+            bias: TestTensor::from_floats([16., 16.]),
+        };
+        test.assert_grads(grads);
+    }
+
+    #[test]
+    fn test_conv_transpose1d_complex() {
+        let test = ConvTranspose1dTestCase {
+            batch_size: 2,
+            channels: [2, 4],
+            kernel_size: 3,
+            padding: 1,
+            padding_out: 1,
+            stride: 2,
+            dilation: 2,
+            groups: 2,
+            size: 8,
+        };
+        let grads = Grads {
+            x: TestTensor::from_floats([
+                [
+                    [12.0, 15.0, 15.0, 15.0, 15.0, 15.0, 15.0, 15.0],
+                    [36.0, 51.0, 51.0, 51.0, 51.0, 51.0, 51.0, 51.0],
+                ],
+                [
+                    [12.0, 15.0, 15.0, 15.0, 15.0, 15.0, 15.0, 15.0],
+                    [36.0, 51.0, 51.0, 51.0, 51.0, 51.0, 51.0, 51.0],
+                ],
+            ]),
+            weight: TestTensor::from_floats([
+                [[168.0, 184.0, 184.0], [168.0, 184.0, 184.0]],
+                [[280.0, 312.0, 312.0], [280.0, 312.0, 312.0]],
+            ]),
+            bias: TestTensor::from_floats([36.0, 36.0, 36.0, 36.0]),
+        };
+        test.assert_grads(grads);
+    }
+
+    struct ConvTranspose1dTestCase {
+        batch_size: usize,
+        channels: [usize; 2],
+        kernel_size: usize,
+        padding: usize,
+        padding_out: usize,
+        stride: usize,
+        dilation: usize,
+        groups: usize,
+        size: usize,
+    }
+
+    struct Grads {
+        x: TestTensor<3>,
+        weight: TestTensor<3>,
+        bias: TestTensor<1>,
+    }
+
+    impl ConvTranspose1dTestCase {
+        fn assert_grads(self, expected_grads: Grads) {
+            let shape_x = Shape::new([self.batch_size, self.channels[0], self.size]);
+            let shape_weight = Shape::new([
+                self.channels[0],
+                self.channels[1] / self.groups,
+                self.kernel_size,
+            ]);
+            let weight = TestADTensor::from_data(
+                TestTensorInt::arange(0..shape_weight.num_elements())
+                    .reshape(shape_weight)
+                    .into_data()
+                    .convert(),
+            )
+            .require_grad();
+            let bias = TestADTensor::from_data(
+                TestTensorInt::arange(0..self.channels[1])
+                    .into_data()
+                    .convert(),
+            )
+            .require_grad();
+            let x = TestADTensor::from_data(
+                TestTensorInt::arange(0..shape_x.num_elements())
+                    .reshape(shape_x)
+                    .into_data()
+                    .convert(),
+            )
+            .require_grad();
+            let output = conv_transpose1d(
+                x.clone(),
+                weight.clone(),
+                Some(bias.clone()),
+                ConvTransposeOptions::new(
+                    [self.stride],
+                    [self.padding],
+                    [self.padding_out],
+                    [self.dilation],
+                    self.groups,
+                ),
+            );
+            let grads = output.backward();
+
+            // Assert
+            let x_grad_actual = x.grad(&grads).unwrap();
+            let weight_grad_actual = weight.grad(&grads).unwrap();
+            let bias_grad_actual = bias.grad(&grads).unwrap();
+
+            println!("{x_grad_actual}");
+            println!("{weight_grad_actual}");
+            println!("{bias_grad_actual}");
+
+            expected_grads
+                .bias
+                .to_data()
+                .assert_approx_eq(&bias_grad_actual.to_data(), 3);
+            expected_grads
+                .x
+                .to_data()
+                .assert_approx_eq(&x_grad_actual.to_data(), 3);
+            expected_grads
+                .weight
+                .to_data()
+                .assert_approx_eq(&weight_grad_actual.to_data(), 3);
+        }
+    }
+}

--- a/burn-autodiff/src/tests/conv_transpose1d.rs
+++ b/burn-autodiff/src/tests/conv_transpose1d.rs
@@ -236,10 +236,6 @@ mod tests {
             let weight_grad_actual = weight.grad(&grads).unwrap();
             let bias_grad_actual = bias.grad(&grads).unwrap();
 
-            println!("{x_grad_actual}");
-            println!("{weight_grad_actual}");
-            println!("{bias_grad_actual}");
-
             expected_grads
                 .bias
                 .to_data()

--- a/burn-autodiff/src/tests/mod.rs
+++ b/burn-autodiff/src/tests/mod.rs
@@ -13,6 +13,7 @@ mod cat;
 mod complex;
 mod conv1d;
 mod conv2d;
+mod conv_transpose1d;
 mod conv_transpose2d;
 mod cos;
 mod cross_entropy;
@@ -58,6 +59,7 @@ macro_rules! testgen_all {
         // Modules
         burn_autodiff::testgen_ad_conv1d!();
         burn_autodiff::testgen_ad_conv2d!();
+        burn_autodiff::testgen_ad_conv_transpose1d!();
         burn_autodiff::testgen_ad_conv_transpose2d!();
         burn_autodiff::testgen_ad_max_pool2d!();
         burn_autodiff::testgen_ad_avg_pool1d!();

--- a/burn-core/src/nn/conv/conv_transpose1d.rs
+++ b/burn-core/src/nn/conv/conv_transpose1d.rs
@@ -1,0 +1,166 @@
+use crate as burn;
+
+use crate::config::Config;
+use crate::module::Module;
+use crate::module::Param;
+use crate::nn::Initializer;
+use crate::tensor::backend::Backend;
+use crate::tensor::Tensor;
+use burn_tensor::module::conv_transpose1d;
+use burn_tensor::ops::ConvTransposeOptions;
+use libm::sqrt;
+
+use super::checks;
+
+/// Configuration to create an [1D transposed convolution](ConvTranspose1d) layer.
+#[derive(Config, Debug)]
+pub struct ConvTranspose1dConfig {
+    /// The number of channels.
+    pub channels: [usize; 2],
+    /// The size of the kernel.
+    pub kernel_size: usize,
+    /// The stride of the convolution.
+    #[config(default = "1")]
+    pub stride: usize,
+    /// Spacing between kernel elements.
+    #[config(default = "1")]
+    pub dilation: usize,
+    /// Controls the connections between input and output channels.
+    #[config(default = "1")]
+    pub groups: usize,
+    /// The padding configuration.
+    #[config(default = "0")]
+    pub padding: usize,
+    /// The padding output configuration.
+    #[config(default = "0")]
+    pub padding_out: usize,
+    /// If bias should be added to the output.
+    #[config(default = true)]
+    pub bias: bool,
+    /// The type of function used to initialize neural network parameters
+    #[config(default = "Initializer::KaimingUniform{gain:1.0/sqrt(3.0),fan_out_only:false}")]
+    pub initializer: Initializer,
+}
+
+/// Applies a 1D transposed convolution over input tensors.
+///
+/// # Params
+///
+/// - weight: Tensor of shape `[channels_in, channels_out / groups, kernel_size]`
+///
+/// - bias:   Tensor of shape `[channels_out]`
+#[derive(Module, Debug)]
+pub struct ConvTranspose1d<B: Backend> {
+    weight: Param<Tensor<B, 3>>,
+    bias: Option<Param<Tensor<B, 1>>>,
+    stride: usize,
+    kernel_size: usize,
+    dilation: usize,
+    groups: usize,
+    padding: usize,
+    padding_out: usize,
+}
+
+impl ConvTranspose1dConfig {
+    /// Initialize a new [conv transpose 1d](ConvTranspose1d) module.
+    pub fn init<B: Backend>(&self) -> ConvTranspose1d<B> {
+        checks::checks_channels_div_groups(self.channels[0], self.channels[1], self.groups);
+
+        let shape = [
+            self.channels[0],
+            self.channels[1] / self.groups,
+            self.kernel_size,
+        ];
+
+        let fan_in = self.channels[1] / self.groups * self.kernel_size;
+        let weight = self.initializer.init_with(shape, Some(fan_in), None);
+        let mut bias = None;
+
+        if self.bias {
+            bias = Some(
+                self.initializer
+                    .init_with([self.channels[1]], Some(fan_in), None),
+            );
+        }
+
+        ConvTranspose1d {
+            weight: Param::from(weight),
+            bias: bias.map(Param::from),
+            stride: self.stride,
+            kernel_size: self.kernel_size,
+            dilation: self.dilation,
+            groups: self.groups,
+            padding: self.padding,
+            padding_out: self.padding_out,
+        }
+    }
+
+    /// Initialize a new [conv transpose 1d](ConvTranspose1d) module with a [record](ConvTranspose1dRecord).
+    pub fn init_with<B: Backend>(&self, record: ConvTranspose1dRecord<B>) -> ConvTranspose1d<B> {
+        ConvTranspose1d {
+            weight: record.weight,
+            bias: record.bias,
+            stride: self.stride,
+            dilation: self.dilation,
+            kernel_size: self.kernel_size,
+            groups: self.groups,
+            padding: self.padding,
+            padding_out: self.padding_out,
+        }
+    }
+}
+
+impl<B: Backend> ConvTranspose1d<B> {
+    /// Applies the forward pass on the input tensor.
+    ///
+    /// # Shapes
+    ///
+    /// - input: [batch_size, channels_in, length_in],
+    /// - output: [batch_size, channels_out, length_out],
+    pub fn forward(&self, input: Tensor<B, 3>) -> Tensor<B, 3> {
+        conv_transpose1d(
+            input,
+            self.weight.val(),
+            self.bias.as_ref().map(|bias| bias.val()),
+            ConvTransposeOptions::new(
+                [self.stride],
+                [self.padding],
+                [self.padding_out],
+                [self.dilation],
+                self.groups,
+            ),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TestBackend;
+    use burn_tensor::Data;
+
+    #[test]
+    fn initializer_default() {
+        TestBackend::seed(0);
+
+        let config = ConvTranspose1dConfig::new([5, 1], 5);
+        let k = (config.channels[1] * config.kernel_size) as f64;
+        let k = sqrt(config.groups as f64 / k) as f32;
+        let conv = config.init::<TestBackend>();
+
+        conv.weight.to_data().assert_within_range(-k..k);
+    }
+
+    #[test]
+    fn initializer_zeros() {
+        TestBackend::seed(0);
+
+        let config = ConvTranspose1dConfig::new([5, 2], 5).with_initializer(Initializer::Zeros);
+        let conv = config.init::<TestBackend>();
+
+        assert_eq!(config.initializer, Initializer::Zeros);
+        conv.weight
+            .to_data()
+            .assert_approx_eq(&Data::zeros(conv.weight.shape()), 3);
+    }
+}

--- a/burn-core/src/nn/conv/mod.rs
+++ b/burn-core/src/nn/conv/mod.rs
@@ -1,9 +1,11 @@
 mod conv1d;
 mod conv2d;
+mod conv_transpose1d;
 mod conv_transpose2d;
 
 pub(crate) mod checks;
 
 pub use conv1d::*;
 pub use conv2d::*;
+pub use conv_transpose1d::*;
 pub use conv_transpose2d::*;

--- a/burn-tensor/src/tensor/ops/modules/base.rs
+++ b/burn-tensor/src/tensor/ops/modules/base.rs
@@ -130,55 +130,6 @@ pub trait ModuleOps<B: Backend> {
 
         B::select_assign(grad, 0, indices, output_grad)
     }
-
-    /// Two dimensional convolution.
-    ///
-    /// # Shapes
-    ///
-    /// x:      `[batch_size, channels_in, height, width]`,
-    /// weight: `[channels_out, channels_in, kernel_size_1, kernel_size_2]`,
-    /// bias:   `[channels_out]`,
-    fn conv2d(
-        x: B::TensorPrimitive<4>,
-        weight: B::TensorPrimitive<4>,
-        bias: Option<B::TensorPrimitive<1>>,
-        options: ConvOptions<2>,
-    ) -> B::TensorPrimitive<4>;
-    /// Two dimensional transposed convolution.
-    ///
-    /// # Shapes
-    ///
-    /// x:      `[batch_size, channels_in, height, width]`,
-    /// weight: `[channels_in, channels_out, kernel_size_1, kernel_size_2]`,
-    /// bias:   `[channels_out]`,
-    fn conv_transpose2d(
-        x: B::TensorPrimitive<4>,
-        weight: B::TensorPrimitive<4>,
-        bias: Option<B::TensorPrimitive<1>>,
-        options: ConvTransposeOptions<2>,
-    ) -> B::TensorPrimitive<4>;
-
-    /// Backward pass for the [conv2d](ModuleOps::conv2d) operation.
-    fn conv2d_backward(
-        x: B::TensorPrimitive<4>,
-        weight: B::TensorPrimitive<4>,
-        bias: Option<B::TensorPrimitive<1>>,
-        output_grad: B::TensorPrimitive<4>,
-        options: ConvOptions<2>,
-    ) -> Conv2dBackward<B> {
-        conv::conv2d_backward(x, weight, bias, output_grad, options)
-    }
-    /// Backward pass for the [conv transpose 2d](ModuleOps::conv_transpose2d) operation.
-    fn conv_transpose2d_backward(
-        x: B::TensorPrimitive<4>,
-        weight: B::TensorPrimitive<4>,
-        bias: Option<B::TensorPrimitive<1>>,
-        output_grad: B::TensorPrimitive<4>,
-        options: ConvTransposeOptions<2>,
-    ) -> Conv2dBackward<B> {
-        conv::conv_transpose2d_backward(x, weight, bias, output_grad, options)
-    }
-
     /// One dimensional convolution.
     ///
     /// # Shapes
@@ -193,6 +144,39 @@ pub trait ModuleOps<B: Backend> {
         options: ConvOptions<1>,
     ) -> B::TensorPrimitive<3> {
         conv::conv1d_from_conv2d::<B>(x, weight, bias, options)
+    }
+    /// Backward pass for the [conv1d](ModuleOps::conv1d) operation.
+    fn conv1d_backward(
+        x: B::TensorPrimitive<3>,
+        weight: B::TensorPrimitive<3>,
+        bias: Option<B::TensorPrimitive<1>>,
+        output_grad: B::TensorPrimitive<3>,
+        options: ConvOptions<1>,
+    ) -> Conv1dBackward<B> {
+        conv::conv1d_backward(x, weight, bias, output_grad, options)
+    }
+    /// Two dimensional convolution.
+    ///
+    /// # Shapes
+    ///
+    /// x:      `[batch_size, channels_in, height, width]`,
+    /// weight: `[channels_out, channels_in, kernel_size_1, kernel_size_2]`,
+    /// bias:   `[channels_out]`,
+    fn conv2d(
+        x: B::TensorPrimitive<4>,
+        weight: B::TensorPrimitive<4>,
+        bias: Option<B::TensorPrimitive<1>>,
+        options: ConvOptions<2>,
+    ) -> B::TensorPrimitive<4>;
+    /// Backward pass for the [conv2d](ModuleOps::conv2d) operation.
+    fn conv2d_backward(
+        x: B::TensorPrimitive<4>,
+        weight: B::TensorPrimitive<4>,
+        bias: Option<B::TensorPrimitive<1>>,
+        output_grad: B::TensorPrimitive<4>,
+        options: ConvOptions<2>,
+    ) -> Conv2dBackward<B> {
+        conv::conv2d_backward(x, weight, bias, output_grad, options)
     }
     /// One dimensional transposed convolution.
     ///
@@ -209,16 +193,41 @@ pub trait ModuleOps<B: Backend> {
     ) -> B::TensorPrimitive<3> {
         conv::conv_transpose1d_from_conv_transpose2d::<B>(x, weight, bias, options)
     }
-    /// Backward pass for the [conv1d](ModuleOps::conv1d) operation.
-    fn conv1d_backward(
+    /// Backward pass for the [conv transpose 1d](ModuleOps::conv_transpose1d) operation.
+    fn conv_transpose1d_backward(
         x: B::TensorPrimitive<3>,
         weight: B::TensorPrimitive<3>,
         bias: Option<B::TensorPrimitive<1>>,
         output_grad: B::TensorPrimitive<3>,
-        options: ConvOptions<1>,
+        options: ConvTransposeOptions<1>,
     ) -> Conv1dBackward<B> {
-        conv::conv1d_backward(x, weight, bias, output_grad, options)
+        conv::conv_transpose1d_backward(x, weight, bias, output_grad, options)
     }
+    /// Two dimensional transposed convolution.
+    ///
+    /// # Shapes
+    ///
+    /// x:      `[batch_size, channels_in, height, width]`,
+    /// weight: `[channels_in, channels_out, kernel_size_1, kernel_size_2]`,
+    /// bias:   `[channels_out]`,
+    fn conv_transpose2d(
+        x: B::TensorPrimitive<4>,
+        weight: B::TensorPrimitive<4>,
+        bias: Option<B::TensorPrimitive<1>>,
+        options: ConvTransposeOptions<2>,
+    ) -> B::TensorPrimitive<4>;
+
+    /// Backward pass for the [conv transpose 2d](ModuleOps::conv_transpose2d) operation.
+    fn conv_transpose2d_backward(
+        x: B::TensorPrimitive<4>,
+        weight: B::TensorPrimitive<4>,
+        bias: Option<B::TensorPrimitive<1>>,
+        output_grad: B::TensorPrimitive<4>,
+        options: ConvTransposeOptions<2>,
+    ) -> Conv2dBackward<B> {
+        conv::conv_transpose2d_backward(x, weight, bias, output_grad, options)
+    }
+
     /// One dimensional avg pooling.
     ///
     /// # Shapes

--- a/burn-tensor/src/tensor/ops/modules/conv.rs
+++ b/burn-tensor/src/tensor/ops/modules/conv.rs
@@ -219,6 +219,60 @@ pub(crate) fn conv_transpose2d_backward<B: Backend>(
     )
 }
 
+/// Calculate the [1D convolution transpose](crate::ops::ModuleOps::conv_transpose1d) backward pass using convolutions.
+pub(crate) fn conv_transpose1d_backward<B: Backend>(
+    x: B::TensorPrimitive<3>,
+    weight: B::TensorPrimitive<3>,
+    bias: Option<B::TensorPrimitive<1>>,
+    output_grad: B::TensorPrimitive<3>,
+    options: ConvTransposeOptions<1>,
+) -> Conv1dBackward<B> {
+    let weight_shape = B::shape(&weight);
+    let weight_device = B::device(&weight);
+
+    let [batch_size, _channels_in, _] = B::shape(&x).dims;
+    let [_, channels_out, length_out] = B::shape(&output_grad).dims;
+
+    let x_grad = B::conv1d(
+        output_grad.clone(),
+        weight,
+        None,
+        ConvOptions::new(
+            options.stride,
+            options.padding,
+            options.dilation,
+            options.groups,
+        ),
+    );
+
+    let weight_grad = match options.groups == 1 {
+        true => conv_transpose1d_weight_grad_no_groups::<B>(
+            x,
+            output_grad.clone(),
+            weight_shape,
+            options,
+        ),
+        false => conv_transpose1d_weight_grad_groups::<B>(
+            x,
+            B::zeros(weight_shape, &weight_device),
+            output_grad.clone(),
+            options,
+        ),
+    };
+
+    Conv1dBackward::new(
+        x_grad,
+        weight_grad,
+        bias.map(|b| {
+            let grad = B::swap_dims(output_grad, 0, 1);
+            let grad = B::reshape(grad, Shape::new([channels_out, batch_size * length_out]));
+            let grad = B::sum_dim(grad, 1);
+
+            B::reshape(grad, B::shape(&b))
+        }),
+    )
+}
+
 /// Execute a 1D convolution using a 2D convolution.
 pub(crate) fn conv1d_from_conv2d<B: Backend>(
     x: B::TensorPrimitive<3>,
@@ -446,6 +500,52 @@ fn conv1d_weight_grad_no_groups<B: Backend>(
     weight_grad
 }
 
+fn conv_transpose1d_weight_grad_groups<B: Backend>(
+    x: B::TensorPrimitive<3>,
+    mut weight_grad: B::TensorPrimitive<3>,
+    output_grad: B::TensorPrimitive<3>,
+    options: ConvTransposeOptions<1>,
+) -> B::TensorPrimitive<3> {
+    let [channels_in, increment_co, kernel_size] = B::shape(&weight_grad).dims;
+    let increment_ci = channels_in / options.groups;
+
+    let x_swapped = B::swap_dims(x, 0, 1);
+    let output_grad_swapped = B::swap_dims(output_grad, 0, 1);
+
+    for g in 0..options.groups {
+        let start_idx_ci = g * increment_ci;
+        let end_idx_ci = (g + 1) * increment_ci;
+        let start_idx_co = g * increment_co;
+        let end_idx_co = (g + 1) * increment_co;
+
+        let x = B::slice(x_swapped.clone(), [start_idx_ci..end_idx_ci]);
+        let grad = B::slice(output_grad_swapped.clone(), [start_idx_co..end_idx_co]);
+        let mut weight_grad_tmp = B::conv1d(
+            grad,
+            x,
+            None,
+            ConvOptions::new(options.dilation, options.padding, options.stride, 1),
+        );
+        weight_grad_tmp = B::swap_dims(weight_grad_tmp, 0, 1);
+        let [_, _, kernel_size_tmp] = B::shape(&weight_grad_tmp).dims;
+
+        if kernel_size_tmp != kernel_size {
+            weight_grad_tmp = B::slice(
+                weight_grad_tmp,
+                [0..increment_ci, 0..increment_co, 0..kernel_size],
+            );
+        }
+
+        weight_grad = B::slice_assign(
+            weight_grad,
+            [start_idx_ci..end_idx_ci, 0..increment_co, 0..kernel_size],
+            weight_grad_tmp,
+        );
+    }
+
+    weight_grad
+}
+
 fn conv2d_weight_grad_no_groups<B: Backend>(
     x: B::TensorPrimitive<4>,
     output_grad: B::TensorPrimitive<4>,
@@ -470,6 +570,37 @@ fn conv2d_weight_grad_no_groups<B: Backend>(
                 0..weight_shape.dims[1],
                 0..weight_shape.dims[2],
                 0..weight_shape.dims[3],
+            ],
+        );
+    }
+    weight_grad
+}
+
+fn conv_transpose1d_weight_grad_no_groups<B: Backend>(
+    x: B::TensorPrimitive<3>,
+    output_grad: B::TensorPrimitive<3>,
+    weight_shape: Shape<3>,
+    options: ConvTransposeOptions<1>,
+) -> B::TensorPrimitive<3> {
+    let x_swapped = B::swap_dims(x, 0, 1);
+    let output_grad_swapped = B::swap_dims(output_grad, 0, 1);
+    let weight_grad_swapped = B::conv1d(
+        output_grad_swapped,
+        x_swapped,
+        None,
+        ConvOptions::new(options.dilation, options.padding, options.stride, 1),
+    );
+    let mut weight_grad = B::swap_dims(weight_grad_swapped, 0, 1);
+
+    let grad_shape = B::shape(&weight_grad);
+
+    if grad_shape != weight_shape {
+        weight_grad = B::slice(
+            weight_grad,
+            [
+                0..weight_shape.dims[0],
+                0..weight_shape.dims[1],
+                0..weight_shape.dims[2],
             ],
         );
     }


### PR DESCRIPTION
Also added the autodiff implementation for adaptiove avg pooling 1d to use the 1d backend functions intead of relying on the 2D (potential performance benefits).