### PR TITLE
Remove topological sort of nodes (clean up)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ strum_macros = "0.24"
 syn = {version = "2.0", features = ["full", "extra-traits"]}
 tempfile = "3.6.0"
 thiserror = "1.0.40"
-topological-sort = "0.2.2"
 
 # WGPU stuff
 futures-intrusive = "0.5"

--- a/burn-import/Cargo.toml
+++ b/burn-import/Cargo.toml
@@ -35,7 +35,6 @@ serde_json = {workspace = true, features = ["std"]}
 strum = {workspace = true}
 strum_macros = {workspace = true}
 syn = {workspace = true, features = ["parsing"]}
-topological-sort = {workspace = true}
 
 [build-dependencies]
 protobuf-codegen = {workspace = true}

--- a/burn-import/src/burn/graph.rs
+++ b/burn-import/src/burn/graph.rs
@@ -455,8 +455,12 @@ impl<PS: PrecisionSettings> BurnGraph<PS> {
         });
 
         output_names.iter().for_each(|output| {
-            self.graph_output_types
-                .push(outputs.get(output).unwrap().clone());
+            self.graph_output_types.push(
+                outputs
+                    .get(output)
+                    .unwrap_or_else(|| panic!("Output type is not found for {output}"))
+                    .clone(),
+            );
         });
     }
 }

--- a/burn-import/src/onnx/ir.rs
+++ b/burn-import/src/onnx/ir.rs
@@ -84,9 +84,6 @@ pub struct ONNXGraph {
     /// The outputs of the graph.
     pub outputs: Vec<Argument>,
 
-    /// The states of the graph.
-    pub states: Vec<State>,
-
     /// The original node names.
     pub old_node_names: HashMap<String, String>,
 


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirm that `run-checks.sh` has been executed.

### Related Issues/PRs

_Provide links to relevant issues and dependent PRs._

### Changes

ONNX nodes should come as topologically sorted, so we are removing it instead, we are making sure the nodes are topologically sorted.

Previously we sorted nodes topologically so that we could identify graph input. However, we changed this algorithm and now removing extra code.

### Testing

Tested on the new ONNX file and checked existing unit tests.
