### PR TITLE
Use buffered io for massive performance gains when loading and saving…

### DIFF
--- a/burn-core/src/record/file.rs
+++ b/burn-core/src/record/file.rs
@@ -2,8 +2,8 @@ use super::{bin_config, PrecisionSettings, Recorder, RecorderError};
 use core::marker::PhantomData;
 use flate2::{read::GzDecoder, write::GzEncoder, Compression};
 use serde::{de::DeserializeOwned, Serialize};
-use std::{fs::File, path::PathBuf};
 use std::io::{BufReader, BufWriter};
+use std::{fs::File, path::PathBuf};
 
 /// Recorder trait specialized to save and load data to and from files.
 pub trait FileRecorder:
@@ -80,10 +80,12 @@ macro_rules! str2reader {
         $file.set_extension(<Self as FileRecorder>::file_extension());
         let path = $file.as_path();
 
-        File::open(path).map_err(|err| match err.kind() {
-            std::io::ErrorKind::NotFound => RecorderError::FileNotFound(err.to_string()),
-            _ => RecorderError::Unknown(err.to_string()),
-        }).map(|file| BufReader::new(file))
+        File::open(path)
+            .map_err(|err| match err.kind() {
+                std::io::ErrorKind::NotFound => RecorderError::FileNotFound(err.to_string()),
+                _ => RecorderError::Unknown(err.to_string()),
+            })
+            .map(|file| BufReader::new(file))
     }};
 }
 
@@ -99,10 +101,12 @@ macro_rules! str2writer {
             std::fs::remove_file(path).map_err(|err| RecorderError::Unknown(err.to_string()))?;
         }
 
-        File::create(path).map_err(|err| match err.kind() {
-            std::io::ErrorKind::NotFound => RecorderError::FileNotFound(err.to_string()),
-            _ => RecorderError::Unknown(err.to_string()),
-        }).map(|file| BufWriter::new(file))
+        File::create(path)
+            .map_err(|err| match err.kind() {
+                std::io::ErrorKind::NotFound => RecorderError::FileNotFound(err.to_string()),
+                _ => RecorderError::Unknown(err.to_string()),
+            })
+            .map(|file| BufWriter::new(file))
     }};
 }
 

--- a/burn-core/src/record/file.rs
+++ b/burn-core/src/record/file.rs
@@ -3,6 +3,7 @@ use core::marker::PhantomData;
 use flate2::{read::GzDecoder, write::GzEncoder, Compression};
 use serde::{de::DeserializeOwned, Serialize};
 use std::{fs::File, path::PathBuf};
+use std::io::{BufReader, BufWriter};
 
 /// Recorder trait specialized to save and load data to and from files.
 pub trait FileRecorder:
@@ -82,7 +83,7 @@ macro_rules! str2reader {
         File::open(path).map_err(|err| match err.kind() {
             std::io::ErrorKind::NotFound => RecorderError::FileNotFound(err.to_string()),
             _ => RecorderError::Unknown(err.to_string()),
-        })
+        }).map(|file| BufReader::new(file))
     }};
 }
 
@@ -101,7 +102,7 @@ macro_rules! str2writer {
         File::create(path).map_err(|err| match err.kind() {
             std::io::ErrorKind::NotFound => RecorderError::FileNotFound(err.to_string()),
             _ => RecorderError::Unknown(err.to_string()),
-        })
+        }).map(|file| BufWriter::new(file))
     }};
 }
 

--- a/burn-import/onnx-tests/tests/onnx_tests.rs
+++ b/burn-import/onnx-tests/tests/onnx_tests.rs
@@ -115,7 +115,7 @@ mod tests {
         let output = model.forward(input);
 
         let expected_shape = Shape::from([2, 6, 6, 15]);
-        assert_eq!(output.shape().clone(), expected_shape);
+        assert_eq!(output.shape(), expected_shape);
 
         // We are using the sum of the output tensor to test the correctness of the conv2d node
         // because the output tensor is too large to compare with the expected tensor.

--- a/burn-import/src/burn/graph.rs
+++ b/burn-import/src/burn/graph.rs
@@ -167,7 +167,7 @@ impl<PS: PrecisionSettings> BurnGraph<PS> {
 
         fn to_tensor(ty: Type) -> Option<TensorType> {
             match ty {
-                Type::Tensor(tensor) => Some(tensor.clone()),
+                Type::Tensor(tensor) => Some(tensor),
                 Type::Scalar(_) => None,
                 Type::Other(_) => None,
             }
@@ -358,7 +358,7 @@ impl<PS: PrecisionSettings> BurnGraph<PS> {
 
         self.graph_input_types.iter().for_each(|input| {
             let name = input.name().clone();
-            let ty = input.ty().clone();
+            let ty = input.ty();
 
             input_def.extend(quote! {
                 #name: #ty,

--- a/burn-import/src/onnx/to_burn.rs
+++ b/burn-import/src/onnx/to_burn.rs
@@ -285,7 +285,7 @@ impl ONNXGraph {
         let rhs = node.inputs.get(1).unwrap().to_type();
         let output = node.outputs.get(0).unwrap().to_type();
 
-        BinaryNode::add(lhs.clone(), rhs.clone(), output.clone())
+        BinaryNode::add(lhs, rhs, output)
     }
 
     fn sub_conversion(node: Node) -> BinaryNode {

--- a/burn-wgpu/src/kernel/prng/base.rs
+++ b/burn-wgpu/src/kernel/prng/base.rs
@@ -28,7 +28,7 @@ pub(crate) fn make_output_tensor<E: WgpuElement, const D: usize>(
     shape: Shape<D>,
 ) -> WgpuTensor<E, D> {
     let buffer = context.create_buffer(shape.num_elements() * core::mem::size_of::<E>());
-    WgpuTensor::new(context.clone(), shape, buffer)
+    WgpuTensor::new(context, shape, buffer)
 }
 
 pub(crate) fn make_info_buffer(context: Arc<Context>, n_values_per_thread: usize) -> Arc<Buffer> {

--- a/burn-wgpu/src/kernel/prng/bernoulli.rs
+++ b/burn-wgpu/src/kernel/prng/bernoulli.rs
@@ -114,13 +114,10 @@ mod tests {
         TestBackend::seed(0);
         let shape = Shape::new([512, 512]);
         let device = WgpuDevice::default();
-        let tensor = Tensor::<TestBackend, 2>::random_device(
-            shape.clone(),
-            Distribution::Bernoulli(0.5),
-            &device,
-        );
+        let tensor =
+            Tensor::<TestBackend, 2>::random_device(shape, Distribution::Bernoulli(0.5), &device);
 
-        let numbers = tensor.clone().into_data().value;
+        let numbers = tensor.into_data().value;
         let stats = calculate_bin_stats(numbers, 2, 0., 1.1);
         let n_0 = stats[0].count as f32;
         let n_1 = stats[1].count as f32;

--- a/burn-wgpu/src/kernel/prng/uniform.rs
+++ b/burn-wgpu/src/kernel/prng/uniform.rs
@@ -108,7 +108,7 @@ mod tests {
             Distribution::Uniform(-5., 10.),
             &device,
         );
-        let numbers = tensor.clone().into_data().value;
+        let numbers = tensor.into_data().value;
         let stats = calculate_bin_stats(numbers, 3, -5., 10.);
         assert!(stats[0].count >= 1);
         assert!(stats[1].count >= 1);
@@ -121,10 +121,9 @@ mod tests {
         TestBackend::seed(0);
         let shape = Shape::new([512, 512]);
         let device = WgpuDevice::default();
-        let tensor =
-            Tensor::<TestBackend, 2>::random_device(shape.clone(), Distribution::Default, &device);
+        let tensor = Tensor::<TestBackend, 2>::random_device(shape, Distribution::Default, &device);
 
-        let numbers = tensor.clone().into_data().value;
+        let numbers = tensor.into_data().value;
         let stats = calculate_bin_stats(numbers, 2, 0., 1.);
         let n_0 = stats[0].count as f32;
         let n_1 = stats[1].count as f32;

--- a/burn-wgpu/src/ops/float_ops.rs
+++ b/burn-wgpu/src/ops/float_ops.rs
@@ -313,7 +313,7 @@ where
     fn from_full_precision<const D: usize>(
         tensor: FloatTensor<FullPrecisionBackend<Self>, D>,
     ) -> FloatTensor<Self, D> {
-        kernel::cast(tensor.clone())
+        kernel::cast(tensor)
     }
 
     fn exp<const D: usize>(lhs: FloatTensor<Self, D>) -> FloatTensor<Self, D> {


### PR DESCRIPTION
… models

## Pull Request Template

### Checklist

- [x] Confirm that `run-checks.sh` has been executed.

### Related Issues/PRs

https://github.com/burn-rs/burn/issues/554

### Changes

The original model IO code did not use buffered IO which resulted in extremely slow model saving and loading for large files. I added buffered IO and found the saving and loading speed to be significantly improved. A once 8 minute load became a matter of seconds.

### Testing

I ran the run-tests.sh script to verify that there were no breaking changes and my own models loaded and ran without issue.
