### PR TITLE
Fix CI

### DIFF
--- a/examples/text-classification/Cargo.toml
+++ b/examples/text-classification/Cargo.toml
@@ -25,7 +25,7 @@ burn-tch = { path = "../../burn-tch", optional = true }
 burn-wgpu = { path = "../../burn-wgpu", optional = true }
 
 # Tokenizer
-tokenizers = { version = "0.13.3", default-features = false, features = [
+tokenizers = { version = "0.13.4", default-features = false, features = [
   "onig",
   "http",
 ] }

--- a/examples/text-classification/src/data/tokenizer.rs
+++ b/examples/text-classification/src/data/tokenizer.rs
@@ -52,7 +52,10 @@ impl Tokenizer for BertCasedTokenizer {
     /// Converts a sequence of tokens back into a text string.
     fn decode(&self, tokens: &[usize]) -> String {
         self.tokenizer
-            .decode(tokens.iter().map(|t| *t as u32).collect(), false)
+            .decode(
+                tokens.iter().map(|t| *t as u32).collect::<Vec<u32>>(),
+                false,
+            )
             .unwrap()
     }
 

--- a/examples/text-classification/src/data/tokenizer.rs
+++ b/examples/text-classification/src/data/tokenizer.rs
@@ -51,12 +51,8 @@ impl Tokenizer for BertCasedTokenizer {
 
     /// Converts a sequence of tokens back into a text string.
     fn decode(&self, tokens: &[usize]) -> String {
-        self.tokenizer
-            .decode(
-                tokens.iter().map(|t| *t as u32).collect::<Vec<u32>>(),
-                false,
-            )
-            .unwrap()
+        let tokens = tokens.iter().map(|t| *t as u32).collect::<Vec<u32>>();
+        self.tokenizer.decode(&tokens, false).unwrap()
     }
 
     /// Gets the size of the BERT cased tokenizer's vocabulary.

--- a/examples/text-generation/Cargo.toml
+++ b/examples/text-generation/Cargo.toml
@@ -17,7 +17,7 @@ burn-autodiff = {path = "../../burn-autodiff"}
 burn-tch = {path = "../../burn-tch"}
 
 # Tokenizer
-tokenizers = {version = "0.13.3", default-features = false, features = [
+tokenizers = {version = "0.13.4", default-features = false, features = [
   "onig",
   "http",
 ]}

--- a/examples/text-generation/src/data/tokenizer.rs
+++ b/examples/text-generation/src/data/tokenizer.rs
@@ -44,12 +44,8 @@ impl Tokenizer for Gpt2Tokenizer {
     }
 
     fn decode(&self, tokens: &[usize]) -> String {
-        self.tokenizer
-            .decode(
-                tokens.iter().map(|t| *t as u32).collect::<Vec<u32>>(),
-                false,
-            )
-            .unwrap()
+        let tokens = tokens.iter().map(|t| *t as u32).collect::<Vec<u32>>();
+        self.tokenizer.decode(&tokens, false).unwrap()
     }
 
     fn vocab_size(&self) -> usize {

--- a/examples/text-generation/src/data/tokenizer.rs
+++ b/examples/text-generation/src/data/tokenizer.rs
@@ -45,7 +45,10 @@ impl Tokenizer for Gpt2Tokenizer {
 
     fn decode(&self, tokens: &[usize]) -> String {
         self.tokenizer
-            .decode(tokens.iter().map(|t| *t as u32).collect(), false)
+            .decode(
+                tokens.iter().map(|t| *t as u32).collect::<Vec<u32>>(),
+                false,
+            )
             .unwrap()
     }
 


### PR DESCRIPTION
The problem:

1. Tokenizers had a breaking change released that wasn't supposed to be breaking change (minor with major > 0).
2. The `Cargo.lock` file isn't commited, since it's not considered when publishing a crate, so the new version was used.