### PR TITLE
Fix bug related to calculation of flatten op output dim

### DIFF
--- a/burn-import/onnx-tests/build.rs
+++ b/burn-import/onnx-tests/build.rs
@@ -14,6 +14,7 @@ fn main() {
         .input("tests/div/div.onnx")
         .input("tests/dropout/dropout_opset16.onnx")
         .input("tests/dropout/dropout_opset7.onnx")
+        .input("tests/flatten/flatten.onnx")
         .input("tests/global_avr_pool/global_avr_pool.onnx")
         .input("tests/log_softmax/log_softmax.onnx")
         .input("tests/maxpool2d/maxpool2d.onnx")

--- a/burn-import/onnx-tests/tests/flatten/flatten.onnx
+++ b/burn-import/onnx-tests/tests/flatten/flatten.onnx
@@ -1,0 +1,13 @@
+pytorch2.0.1:}
+4
+onnx::Flatten_01/Flatten"Flatten*
+axis 	torch_jitZ%
+onnx::Flatten_0
+
+
+
+b
+1
+
+
+KB

--- a/burn-import/onnx-tests/tests/flatten/flatten.py
+++ b/burn-import/onnx-tests/tests/flatten/flatten.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+# used to generate model: flatten.onnx
+
+import torch
+import torch.nn as nn
+
+
+class Model(nn.Module):
+    def __init__(self):
+        super(Model, self).__init__()
+
+    def forward(self, x):
+        x = x.flatten(1, 2)
+        return x
+
+
+def main():
+
+    # Set seed for reproducibility
+    torch.manual_seed(42)
+
+    torch.set_printoptions(precision=8)
+
+    # Export to onnx
+    model = Model()
+    model.eval()
+    device = torch.device("cpu")
+
+    file_name = "flatten.onnx"
+    test_input =  torch.ones(1, 5, 15, device=device)
+    torch.onnx.export(model, test_input, file_name,
+                      verbose=False, opset_version=16)
+
+    print("Finished exporting model to {}".format(file_name))
+
+    # Output some test data for use in the test
+    print("Test input data of ones: {}".format(test_input))
+    print("Test input data shape of ones: {}".format(test_input.shape))
+    output = model.forward(test_input)
+    print("Test output data shape: {}".format(output.shape))
+
+
+if __name__ == '__main__':
+    main()

--- a/burn-import/onnx-tests/tests/onnx_tests.rs
+++ b/burn-import/onnx-tests/tests/onnx_tests.rs
@@ -19,6 +19,7 @@ include_models!(
     div,
     dropout_opset16,
     dropout_opset7,
+    flatten,
     global_avr_pool,
     log_softmax,
     maxpool2d,
@@ -308,5 +309,18 @@ mod tests {
         let expected = Data::from([[0., 1., 2., 3.]]);
 
         assert_eq!(output.to_data(), expected);
+    }
+
+    #[test]
+    fn flatten() {
+        // Initialize the model without weights (because the exported file does not contain them)
+        let model: flatten::Model<Backend> = flatten::Model::new();
+
+        // Run the model
+        let input = Tensor::<Backend, 3>::ones([1, 5, 15]);
+        let output = model.forward(input);
+
+        let expected_shape = Shape::from([1, 75]);
+        assert_eq!(expected_shape, output.shape());
     }
 }

--- a/burn-import/src/onnx/dim_inference.rs
+++ b/burn-import/src/onnx/dim_inference.rs
@@ -297,12 +297,23 @@ fn flatten_update_outputs(node: &mut Node) {
     if node.inputs.len() != 1 {
         panic!("Flatten: multiple inputs are not supported");
     }
+    let tensor = node
+        .inputs
+        .iter()
+        .find_map(|input| match &input.ty {
+            ArgType::Tensor(tensor) => Some(tensor),
+            _ => None,
+        })
+        .unwrap();
+
+    let input_dim = tensor.dim;
 
     let (start_dim, end_dim) = flatten_config(node);
 
-    node.outputs[0].ty = ArgType::Tensor(TensorArg {
-        dim: end_dim - start_dim,
-    });
+    let collapsed_dims = end_dim - start_dim;
+    let output_dim = input_dim - collapsed_dims;
+
+    node.outputs[0].ty = ArgType::Tensor(TensorArg { dim: output_dim });
 }
 
 /// Infers the shape of a Conv1d node and replaces the shape of the output tensor.

--- a/burn-tensor/src/tensor/api/check.rs
+++ b/burn-tensor/src/tensor/api/check.rs
@@ -154,6 +154,16 @@ impl TensorCheck {
             );
         }
 
+        if D2 < D1 - (end_dim - start_dim) {
+            check = check.register(
+                "Flatten",
+                TensorError::new(format!(
+                    "The destination dimension ({D2}) must be large enough to accommodate the flattening operation."
+
+                )),
+            );
+        }
+
         check
     }
 

--- a/burn-tensor/src/tests/ops/flatten.rs
+++ b/burn-tensor/src/tests/ops/flatten.rs
@@ -46,4 +46,13 @@ mod tests {
         let tensor = Tensor::<TestBackend, 4>::ones(Shape::new([2, 3, 4, 5]));
         let flattened_tensor: Tensor<TestBackend, 2> = tensor.flatten(2, 0);
     }
+
+    #[test]
+    #[should_panic]
+    fn not_enough_destination_dimension() {
+        let tensor = Tensor::<TestBackend, 3>::ones(Shape::new([1, 5, 15]));
+        let flattened_tensor: Tensor<TestBackend, 1> = tensor.flatten(1, 2);
+        let expected_shape = Shape::new([75]);
+        assert_eq!(flattened_tensor.shape(), expected_shape);
+    }
 }


### PR DESCRIPTION
Fixes #646

## Pull Request Template

### Checklist

- [x] Confirm that `run-checks` script has been executed.

### Related Issues/PRs

https://github.com/burn-rs/burn/issues/646

### Changes

1. Identified the bug related to ONNX flatten operation. The output dimension was incorrectly calculated.
2. Added ONNX file tests.
3. Added a new case for flatten tensor check.


### Testing

Added new tests (onnx file and tensor test)