### PR TITLE
Add `clippy` checks to continuous integration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,8 +57,18 @@ jobs:
           sudo apt-get update
           sudo apt install -y libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
 
+      - name: Run cargo clippy for stable version
+        if: matrix.rust == 'stable' && matrix.test == 'std'
+        uses: giraffate/clippy-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Run clippy for each workspace, targets, and featrues, considering
+          # warnings as errors
+          clippy_flags: --workspace --all-targets --all-features -- -D warnings
+          reporter: github-pr-check
+
       - name: run checks & tests
-        run: RUST_MATRIX=${{ matrix.rust }} cargo xtask run-checks ${{ matrix.test }}
+        run: CI_RUN=1 cargo xtask run-checks ${{ matrix.test }}
 
   check-typos:
     runs-on: ubuntu-latest

--- a/xtask/src/runchecks.rs
+++ b/xtask/src/runchecks.rs
@@ -106,7 +106,7 @@ fn cargo_fmt() {
 
 // Run cargo clippy command
 fn cargo_clippy() {
-    if std::env::var("RUST_MATRIX").map_or(false, |matrix| matrix != "stable") {
+    if std::env::var("CI_RUN").is_ok() {
         return;
     }
     // Run cargo clippy


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirm that `run-checks` script has been executed.

### Changes

This PR adds `clippy` checks on Linux directly on CI and uses actions to better show in PR `clippy` warnings. It updates #552 
