### PR TITLE
Remove channel field from maxpool1d config struct

### DIFF
--- a/burn-core/src/nn/pool/max_pool1d.rs
+++ b/burn-core/src/nn/pool/max_pool1d.rs
@@ -10,8 +10,6 @@ use burn_tensor::module::max_pool1d;
 /// Configuration to create a [1D max pooling](MaxPool1d) layer.
 #[derive(Config)]
 pub struct MaxPool1dConfig {
-    /// The number of channels.
-    pub channels: usize,
     /// The size of the kernel.
     pub kernel_size: usize,
     /// The stride.


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirm that `run-checks` script has been executed.

### Changes
This PR removes the channels field from the ```MaxPool1dConfig``` struct as it is not necessary to perform the operation

### Testing

Ran the checks which includes ```max_pool1d``` testing. 
