### PR TITLE
Improved Error messages by showing location of invocation.

### DIFF
--- a/burn-core/src/nn/attention/mha.rs
+++ b/burn-core/src/nn/attention/mha.rs
@@ -154,6 +154,7 @@ impl<B: Backend> MultiHeadAttention<B> {
     /// - key: `[batch_size, seq_length_2, d_model]`
     /// - value: `[batch_size, seq_length_2, d_model]`
     /// - output: `[batch_size, seq_length_1, d_model]`
+    #[track_caller]
     pub fn forward(&self, input: MhaInput<B>) -> MhaOutput<B> {
         let [batch_size, seq_length_1, d_model] = input.query.dims();
 
@@ -181,6 +182,7 @@ impl<B: Backend> MultiHeadAttention<B> {
     /// - key: `[batch_size, seq_length_2, d_model]`
     /// - value: `[batch_size, seq_length_2, d_model]`
     /// - output: `[batch_size, seq_length_1, d_model]`
+    #[track_caller]
     pub fn forward_cache(&self, input: MhaInput<B>, cache: &mut MhaCache<B>) -> MhaOutput<B> {
         let [batch_size, seq_length_1, d_model] = input.query.dims();
 

--- a/burn-core/src/nn/cache/autoregressive.rs
+++ b/burn-core/src/nn/cache/autoregressive.rs
@@ -5,6 +5,7 @@ use crate::tensor::backend::Backend;
 use crate::tensor::Tensor;
 
 impl<B: Backend, const D: usize> TensorCache<B, D> {
+    #[track_caller]
     pub(crate) fn forward_autoregressive<F>(
         &mut self,
         tensor: Tensor<B, 3>,
@@ -33,6 +34,7 @@ impl<B: Backend, const D: usize> TensorCache<B, D> {
         tensor_new
     }
 
+    #[track_caller]
     pub(crate) fn forward_full<F>(&mut self, tensor: Tensor<B, 3>, func: F) -> Tensor<B, D>
     where
         F: Fn(Tensor<B, 3>) -> Tensor<B, D>,

--- a/burn-core/src/nn/conv/conv1d.rs
+++ b/burn-core/src/nn/conv/conv1d.rs
@@ -112,6 +112,7 @@ impl<B: Backend> Conv1d<B> {
     ///
     /// - input: [batch_size, channels_in, length_in],
     /// - output: [batch_size, channels_out, length_out],
+    #[track_caller]
     pub fn forward(&self, input: Tensor<B, 3>) -> Tensor<B, 3> {
         let [_batch_size, _channels, length] = input.dims();
         let padding = self

--- a/burn-core/src/nn/conv/conv2d.rs
+++ b/burn-core/src/nn/conv/conv2d.rs
@@ -113,6 +113,7 @@ impl<B: Backend> Conv2d<B> {
     ///
     /// - input: [batch_size, channels_in, height_in, width_in],
     /// - output: [batch_size, channels_out, height_out, width_out],
+    #[track_caller]
     pub fn forward(&self, input: Tensor<B, 4>) -> Tensor<B, 4> {
         let [_batch_size, _channels_in, height_in, width_in] = input.dims();
         let padding =

--- a/burn-core/src/nn/conv/conv_transpose1d.rs
+++ b/burn-core/src/nn/conv/conv_transpose1d.rs
@@ -117,6 +117,7 @@ impl<B: Backend> ConvTranspose1d<B> {
     ///
     /// - input: [batch_size, channels_in, length_in],
     /// - output: [batch_size, channels_out, length_out],
+    #[track_caller]
     pub fn forward(&self, input: Tensor<B, 3>) -> Tensor<B, 3> {
         conv_transpose1d(
             input,

--- a/burn-core/src/nn/conv/conv_transpose2d.rs
+++ b/burn-core/src/nn/conv/conv_transpose2d.rs
@@ -118,6 +118,7 @@ impl<B: Backend> ConvTranspose2d<B> {
     ///
     /// - input: [batch_size, channels_in, height_in, width_in],
     /// - output: [batch_size, channels_out, height_out, width_out],
+    #[track_caller]
     pub fn forward(&self, input: Tensor<B, 4>) -> Tensor<B, 4> {
         conv_transpose2d(
             input,

--- a/burn-core/src/nn/dropout.rs
+++ b/burn-core/src/nn/dropout.rs
@@ -37,6 +37,7 @@ impl Dropout {
     ///
     /// - input: `[..., any]`
     /// - output: `[..., any]`
+    #[track_caller]
     pub fn forward<B: Backend, const D: usize>(&self, input: Tensor<B, D>) -> Tensor<B, D> {
         if !B::ad_enabled() || self.prob == 0.0 {
             return input;

--- a/burn-core/src/nn/embedding.rs
+++ b/burn-core/src/nn/embedding.rs
@@ -58,6 +58,7 @@ impl<B: Backend> Embedding<B> {
     ///
     /// - input: [batch_size, seq_length]
     /// - output: [batch_size, d_model]
+    #[track_caller]
     pub fn forward(&self, input: Tensor<B, 2, Int>) -> Tensor<B, 3> {
         burn_tensor::module::embedding(self.weight.val(), input)
     }

--- a/burn-core/src/nn/gelu.rs
+++ b/burn-core/src/nn/gelu.rs
@@ -20,6 +20,7 @@ impl GELU {
     ///
     /// - input: `[..., any]`
     /// - output: `[..., any]`
+    #[track_caller]
     pub fn forward<B: Backend, const D: usize>(&self, input: Tensor<B, D>) -> Tensor<B, D> {
         crate::tensor::activation::gelu(input)
     }

--- a/burn-core/src/nn/linear.rs
+++ b/burn-core/src/nn/linear.rs
@@ -79,6 +79,8 @@ impl<B: Backend> Linear<B> {
     ///
     /// - input: `[..., any, d_input]`
     /// - output: `[..., any, d_output]`
+    // #[track_caller]
+    #[track_caller]
     pub fn forward<const D: usize>(&self, input: Tensor<B, D>) -> Tensor<B, D> {
         let output = input.matmul(self.weight.val().unsqueeze());
 

--- a/burn-core/src/nn/loss/cross_entropy.rs
+++ b/burn-core/src/nn/loss/cross_entropy.rs
@@ -24,6 +24,7 @@ impl<B: Backend> CrossEntropyLoss<B> {
     ///
     /// - logits: `[batch_size, num_targets]`
     /// - targets: `[batch_size]`
+    #[track_caller]
     pub fn forward(&self, logits: Tensor<B, 2>, targets: Tensor<B, 1, Int>) -> Tensor<B, 1> {
         let [batch_size] = targets.dims();
 

--- a/burn-core/src/nn/norm/batch.rs
+++ b/burn-core/src/nn/norm/batch.rs
@@ -74,6 +74,7 @@ impl<const D: usize, B: Backend> BatchNorm<B, D> {
     ///
     /// - input: `[batch_size, channels, ...]`
     /// - output: `[batch_size, channels, ...]`
+    #[track_caller]
     pub fn forward<const DI: usize>(&self, input: Tensor<B, DI>) -> Tensor<B, DI> {
         // Should be move to a compilation error when const generic support that kind of
         // validation. https://github.com/rust-lang/rust/issues/76560
@@ -87,6 +88,7 @@ impl<const D: usize, B: Backend> BatchNorm<B, D> {
         }
     }
 
+    #[track_caller]
     fn forward_inference<const DI: usize>(&self, input: Tensor<B, DI>) -> Tensor<B, DI> {
         let channels = input.dims()[1];
         let mean = self.running_mean.value();
@@ -98,6 +100,7 @@ impl<const D: usize, B: Backend> BatchNorm<B, D> {
         self.forward_shared(input, mean.reshape(shape), var.reshape(shape))
     }
 
+    #[track_caller]
     fn forward_train<const DI: usize>(&self, input: Tensor<B, DI>) -> Tensor<B, DI> {
         let dims = input.dims();
         let batch_size = dims[0];
@@ -149,6 +152,7 @@ impl<const D: usize, B: Backend> BatchNorm<B, D> {
         self.forward_shared(input, mean, var)
     }
 
+    #[track_caller]
     fn forward_shared<const DI: usize>(
         &self,
         x: Tensor<B, DI>,

--- a/burn-core/src/nn/norm/layer.rs
+++ b/burn-core/src/nn/norm/layer.rs
@@ -56,6 +56,7 @@ impl<B: Backend> LayerNorm<B> {
     ///
     /// - input: `[..., any, d_model]`
     /// - output: `[..., any, d_model]`
+    #[track_caller]
     pub fn forward<const D: usize>(&self, input: Tensor<B, D>) -> Tensor<B, D> {
         let (var, mean) = input.clone().var_mean_bias(D - 1);
 

--- a/burn-core/src/nn/pool/adaptive_avg_pool1d.rs
+++ b/burn-core/src/nn/pool/adaptive_avg_pool1d.rs
@@ -35,6 +35,7 @@ impl AdaptiveAvgPool1d {
     ///
     /// - input: [batch_size, channels, length],
     /// - output: [batch_size, channels, length_out],
+    #[track_caller]
     pub fn forward<B: Backend>(&self, input: Tensor<B, 3>) -> Tensor<B, 3> {
         adaptive_avg_pool1d(input, self.output_size)
     }

--- a/burn-core/src/nn/pool/adaptive_avg_pool2d.rs
+++ b/burn-core/src/nn/pool/adaptive_avg_pool2d.rs
@@ -35,6 +35,7 @@ impl AdaptiveAvgPool2d {
     ///
     /// - input: [batch_size, channels, height_in, width_in],
     /// - output: [batch_size, channels, height_out, width_out],
+    #[track_caller]
     pub fn forward<B: Backend>(&self, input: Tensor<B, 4>) -> Tensor<B, 4> {
         adaptive_avg_pool2d(input, self.output_size)
     }

--- a/burn-core/src/nn/pool/avg_pool1d.rs
+++ b/burn-core/src/nn/pool/avg_pool1d.rs
@@ -65,6 +65,7 @@ impl AvgPool1d {
     ///
     /// - input: [batch_size, channels, length_in],
     /// - output: [batch_size, channels, length_out],
+    #[track_caller]
     pub fn forward<B: Backend>(&self, input: Tensor<B, 3>) -> Tensor<B, 3> {
         let [_batch_size, _channels, length] = input.dims();
         let padding = self

--- a/burn-core/src/nn/pool/avg_pool2d.rs
+++ b/burn-core/src/nn/pool/avg_pool2d.rs
@@ -64,6 +64,7 @@ impl AvgPool2d {
     ///
     /// - input: [batch_size, channels, height_in, width_in],
     /// - output: [batch_size, channels, height_out, width_out],
+    #[track_caller]
     pub fn forward<B: Backend>(&self, input: Tensor<B, 4>) -> Tensor<B, 4> {
         let [_batch_size, _channels_in, height_in, width_in] = input.dims();
         let padding =

--- a/burn-core/src/nn/pool/max_pool1d.rs
+++ b/burn-core/src/nn/pool/max_pool1d.rs
@@ -46,6 +46,7 @@ impl MaxPool1d {
     ///
     /// - input: [batch_size, channels, length_in],
     /// - output: [batch_size, channels, length_out],
+    #[track_caller]
     pub fn forward<B: Backend>(&self, input: Tensor<B, 3>) -> Tensor<B, 3> {
         let [_batch_size, _channels, length] = input.dims();
         let padding = self

--- a/burn-core/src/nn/pool/max_pool2d.rs
+++ b/burn-core/src/nn/pool/max_pool2d.rs
@@ -46,6 +46,7 @@ impl MaxPool2d {
     ///
     /// - input: [batch_size, channels, height_in, width_in],
     /// - output: [batch_size, channels, height_out, width_out],
+    #[track_caller]
     pub fn forward<B: Backend>(&self, input: Tensor<B, 4>) -> Tensor<B, 4> {
         let [_batch_size, _channels_in, height_in, width_in] = input.dims();
         let padding =

--- a/burn-core/src/nn/pos_encoding.rs
+++ b/burn-core/src/nn/pos_encoding.rs
@@ -65,6 +65,7 @@ impl<B: Backend> PositionalEncoding<B> {
     ///
     /// * Panics if the input sequence length is greater than the maximum sequence size.
     /// * Panics if the input d_model is not equal to the d_model of the sinusoids.
+    #[track_caller]
     pub fn forward(&self, input: Tensor<B, 3>) -> Tensor<B, 3> {
         let [_, seq_length, d_model_input] = input.dims();
 

--- a/burn-core/src/nn/relu.rs
+++ b/burn-core/src/nn/relu.rs
@@ -21,6 +21,7 @@ impl ReLU {
     ///
     /// - input: `[..., any]`
     /// - output: `[..., any]`
+    #[track_caller]
     pub fn forward<B: Backend, const D: usize>(&self, input: Tensor<B, D>) -> Tensor<B, D> {
         crate::tensor::activation::relu(input)
     }

--- a/burn-core/src/nn/rnn/gru.rs
+++ b/burn-core/src/nn/rnn/gru.rs
@@ -106,6 +106,7 @@ impl<B: Backend> Gru<B> {
     ///
     /// Returns:
     ///     The resulting state tensor, with shape [batch_size, sequence_length, hidden_size].
+    #[track_caller]
     pub fn forward(
         &mut self,
         batched_input: Tensor<B, 3>,

--- a/burn-core/src/nn/rnn/lstm.rs
+++ b/burn-core/src/nn/rnn/lstm.rs
@@ -122,6 +122,7 @@ impl<B: Backend> Lstm<B> {
     ///     A tuple of tensors, where the first tensor represents the cell states and
     ///     the second tensor represents the hidden states for each sequence element.
     ///     Both output tensors have the shape [batch_size, sequence_length, hidden_size].
+    #[track_caller]
     pub fn forward(
         &mut self,
         batched_input: Tensor<B, 3>,

--- a/burn-core/src/nn/transformer/decoder.rs
+++ b/burn-core/src/nn/transformer/decoder.rs
@@ -235,6 +235,7 @@ impl<B: Backend> TransformerDecoderLayer<B> {
         }
     }
 
+    #[track_caller]
     fn forward(&self, mut input: TransformerDecoderInput<B>) -> TransformerDecoderInput<B> {
         let mut x_0 = input.target;
 
@@ -278,6 +279,7 @@ impl<B: Backend> TransformerDecoderLayer<B> {
         input
     }
 
+    #[track_caller]
     fn forward_autoregressive_inference(
         &self,
         mut input: TransformerDecoderInput<B>,
@@ -341,6 +343,7 @@ impl<B: Backend> TransformerDecoderLayer<B> {
 
 impl<B: Backend> TransformerDecoder<B> {
     /// Applies the forward pass.
+    #[track_caller]
     pub fn forward(&self, mut input: TransformerDecoderInput<B>) -> Tensor<B, 3> {
         for layer in self.layers.iter() {
             input = layer.forward(input);
@@ -350,6 +353,7 @@ impl<B: Backend> TransformerDecoder<B> {
     }
 
     /// Applies the forward pass on the input using autoregressive cache.
+    #[track_caller]
     pub fn forward_autoregressive_inference(
         &self,
         mut input: TransformerDecoderInput<B>,

--- a/burn-core/src/nn/transformer/encoder.rs
+++ b/burn-core/src/nn/transformer/encoder.rs
@@ -108,6 +108,7 @@ impl<B: Backend> TransformerEncoder<B> {
     ///
     /// - tensor: `[batch_size, seq_length, d_model]`
     /// - output: `[batch_size, seq_length, d_model]`
+    #[track_caller]
     pub fn forward(&self, input: TransformerEncoderInput<B>) -> Tensor<B, 3> {
         let mut x = input.tensor;
 
@@ -123,6 +124,7 @@ impl<B: Backend> TransformerEncoder<B> {
     ///
     /// - tensor: `[batch_size, seq_length, d_model]`
     /// - output: `[batch_size, seq_length, d_model]`
+    #[track_caller]
     pub fn forward_autoregressive_inference(
         &self,
         input: TransformerEncoderInput<B>,
@@ -207,6 +209,7 @@ impl<B: Backend> TransformerEncoderLayer<B> {
         }
     }
 
+    #[track_caller]
     fn forward(
         &self,
         mut input: Tensor<B, 3>,
@@ -241,6 +244,7 @@ impl<B: Backend> TransformerEncoderLayer<B> {
         x_2
     }
 
+    #[track_caller]
     fn forward_autoregressive_inference(
         &self,
         mut input: Tensor<B, 3>,

--- a/burn-core/src/nn/transformer/pwff.rs
+++ b/burn-core/src/nn/transformer/pwff.rs
@@ -65,6 +65,7 @@ impl<B: Backend> PositionWiseFeedForward<B> {
     ///
     /// - tensor: `[batch_size, seq_length, d_model]`
     /// - output: `[batch_size, seq_length, d_model]`
+    #[track_caller]
     pub fn forward<const D: usize>(&self, input: Tensor<B, D>) -> Tensor<B, D> {
         let x = self.linear_inner.forward(input);
         let x = self.gelu.forward(x);

--- a/burn-tensor/src/tensor/activation/base.rs
+++ b/burn-tensor/src/tensor/activation/base.rs
@@ -21,6 +21,7 @@ pub fn gelu<const D: usize, B: Backend>(tensor: Tensor<B, D>) -> Tensor<B, D> {
 ///
 /// The dimension argument `dim` specifies the dimension along which the function will be computed.
 /// It must in the range of `0` and `D-1`.
+#[track_caller]
 pub fn softmax<const D: usize, B: Backend>(tensor: Tensor<B, D>, dim: usize) -> Tensor<B, D> {
     check!(TensorCheck::dim_ops::<D>("softmax", dim));
 
@@ -39,6 +40,7 @@ pub fn softmax<const D: usize, B: Backend>(tensor: Tensor<B, D>, dim: usize) -> 
 ///
 /// The dimension argument `dim` specifies the dimension along which the function will be computed.
 /// It must in the range of `0` and `D-1`.
+#[track_caller]
 pub fn log_softmax<const D: usize, B: Backend>(tensor: Tensor<B, D>, dim: usize) -> Tensor<B, D> {
     check!(TensorCheck::dim_ops::<D>("log softmax", dim));
 

--- a/burn-tensor/src/tensor/api/base.rs
+++ b/burn-tensor/src/tensor/api/base.rs
@@ -129,6 +129,7 @@ where
     /// }
     ///
     /// ```
+    #[track_caller]
     pub fn flatten<const D2: usize>(self, start_dim: usize, end_dim: usize) -> Tensor<B, D2, K> {
         check!(TensorCheck::flatten::<D, D2>(start_dim, end_dim));
 
@@ -179,6 +180,7 @@ where
     ///     println!("{:?}", squeezed_tensor.shape());
     /// }
     /// ```
+    #[track_caller]
     pub fn squeeze<const D2: usize>(self, dim: usize) -> Tensor<B, D2, K> {
         check!(TensorCheck::squeeze::<D2>(dim, &self.shape().dims));
 
@@ -210,6 +212,7 @@ where
     ///     // Shape { dims: [1, 1, 3, 3] }
     /// }
     /// ```
+    #[track_caller]
     pub fn unsqueeze<const D2: usize>(self) -> Tensor<B, D2, K> {
         check!(TensorCheck::unsqueeze::<D, D2>());
 
@@ -242,6 +245,7 @@ where
     ///     
     /// }
     /// ```
+    #[track_caller]
     pub fn slice<const D2: usize>(self, ranges: [core::ops::Range<usize>; D2]) -> Self {
         check!(TensorCheck::slice(&self.shape(), &ranges));
         Self::new(K::slice(self.primitive, ranges))
@@ -268,6 +272,7 @@ where
     ///     println!("{:?}", tensor_sliced.dims()); // [2, 3, 3]
     /// }
     /// ```
+    #[track_caller]
     pub fn slice_assign<const D2: usize>(
         self,
         ranges: [core::ops::Range<usize>; D2],
@@ -331,6 +336,7 @@ where
     /// # Panics
     ///
     /// If the two tensors don't have the same shape.
+    #[track_caller]
     pub fn equal(self, other: Self) -> Tensor<B, D, Bool> {
         check!(TensorCheck::binary_ops_ew("Equal", &self, &other));
         K::equal(self.primitive, other.primitive)
@@ -341,6 +347,7 @@ where
     /// # Panics
     ///
     /// If all tensors don't have the same shape.
+    #[track_caller]
     pub fn cat(tensors: Vec<Self>, dim: usize) -> Self {
         check!(TensorCheck::cat(&tensors, dim));
 
@@ -971,6 +978,7 @@ pub trait ReshapeArgs<const D2: usize> {
 }
 
 impl<const D2: usize> ReshapeArgs<D2> for Shape<D2> {
+    #[track_caller]
     fn into_shape<B: Backend, const D: usize, K: BasicOps<B>>(
         self,
         tensor: &Tensor<B, D, K>,
@@ -981,6 +989,7 @@ impl<const D2: usize> ReshapeArgs<D2> for Shape<D2> {
     }
 }
 impl<const D2: usize> ReshapeArgs<D2> for [usize; D2] {
+    #[track_caller]
     fn into_shape<B: Backend, const D: usize, K: BasicOps<B>>(
         self,
         tensor: &Tensor<B, D, K>,
@@ -994,6 +1003,7 @@ impl<const D2: usize> ReshapeArgs<D2> for [usize; D2] {
 }
 
 impl<const D2: usize> ReshapeArgs<D2> for [i32; D2] {
+    #[track_caller]
     fn into_shape<B: Backend, const D: usize, K: BasicOps<B>>(
         self,
         tensor: &Tensor<B, D, K>,

--- a/burn-tensor/src/tensor/api/float.rs
+++ b/burn-tensor/src/tensor/api/float.rs
@@ -180,6 +180,7 @@ where
     /// # Panics
     ///
     /// If the dimensions exceed the shape of than the tensor.
+    #[track_caller]
     pub fn swap_dims(self, dim1: usize, dim2: usize) -> Self {
         check!(TensorCheck::swap_dims::<D>(dim1, dim2));
         Self::new(B::swap_dims(self.primitive, dim1, dim2))
@@ -192,6 +193,7 @@ where
     /// # Panics
     ///
     /// If the two tensors dont' have a compatible shape.
+    #[track_caller]
     pub fn matmul(self, other: Self) -> Self {
         check!(TensorCheck::matmul(&self, &other));
         Self::new(B::matmul(self.primitive, other.primitive))

--- a/burn-tensor/src/tensor/api/numeric.rs
+++ b/burn-tensor/src/tensor/api/numeric.rs
@@ -14,6 +14,7 @@ where
     /// # Panics
     ///
     /// If the tensor doesn't have one element.
+    #[track_caller]
     pub fn into_scalar(self) -> K::Elem {
         check!(TensorCheck::into_scalar(&self.shape()));
         let data = self.into_data();
@@ -23,6 +24,7 @@ where
     ///
     /// `y = x2 + x1`
     #[allow(clippy::should_implement_trait)]
+    #[track_caller]
     pub fn add(self, other: Self) -> Self {
         check!(TensorCheck::binary_ops_ew("Add", &self, &other));
         Self::new(K::add(self.primitive, other.primitive))
@@ -39,6 +41,7 @@ where
     ///
     /// `y = x2 - x1`
     #[allow(clippy::should_implement_trait)]
+    #[track_caller]
     pub fn sub(self, other: Self) -> Self {
         check!(TensorCheck::binary_ops_ew("Sub", &self, &other));
         Self::new(K::sub(self.primitive, other.primitive))
@@ -55,6 +58,7 @@ where
     ///
     /// `y = x2 / x1`
     #[allow(clippy::should_implement_trait)]
+    #[track_caller]
     pub fn div(self, other: Self) -> Self {
         check!(TensorCheck::binary_ops_ew("Div", &self, &other));
         Self::new(K::div(self.primitive, other.primitive))
@@ -71,6 +75,7 @@ where
     ///
     /// `y = x2 * x1`
     #[allow(clippy::should_implement_trait)]
+    #[track_caller]
     pub fn mul(self, other: Self) -> Self {
         check!(TensorCheck::binary_ops_ew("Mul", &self, &other));
         Self::new(K::mul(self.primitive, other.primitive))
@@ -136,12 +141,14 @@ where
     }
 
     /// Aggregate all elements along the given *dimension* or *axis* in the tensor with the mean operation.
+    #[track_caller]
     pub fn mean_dim(self, dim: usize) -> Self {
         check!(TensorCheck::aggregate_dim::<D>("Mean", dim));
         Self::new(K::mean_dim(self.primitive, dim))
     }
 
     /// Aggregate all elements along the given *dimension* or *axis* in the tensor with the sum operation.
+    #[track_caller]
     pub fn sum_dim(self, dim: usize) -> Self {
         check!(TensorCheck::aggregate_dim::<D>("Sum", dim));
         Self::new(K::sum_dim(self.primitive, dim))
@@ -157,6 +164,7 @@ where
     /// # Panics
     ///
     /// If the two tensors don't have the same shape.
+    #[track_caller]
     pub fn greater(self, other: Self) -> Tensor<B, D, Bool> {
         check!(TensorCheck::binary_ops_ew("Greater", &self, &other));
         K::greater(self.primitive, other.primitive)
@@ -167,6 +175,7 @@ where
     /// # Panics
     ///
     /// If the two tensors don't have the same shape.
+    #[track_caller]
     pub fn greater_equal(self, other: Self) -> Tensor<B, D, Bool> {
         check!(TensorCheck::binary_ops_ew("Greater_equal", &self, &other));
         K::greater_equal(self.primitive, other.primitive)
@@ -177,6 +186,7 @@ where
     /// # Panics
     ///
     /// If the two tensors don't have the same shape.
+    #[track_caller]
     pub fn lower(self, other: Self) -> Tensor<B, D, Bool> {
         check!(TensorCheck::binary_ops_ew("Lower", &self, &other));
         K::lower(self.primitive, other.primitive)
@@ -187,6 +197,7 @@ where
     /// # Panics
     ///
     /// If the two tensors don't have the same shape.
+    #[track_caller]
     pub fn lower_equal(self, other: Self) -> Tensor<B, D, Bool> {
         check!(TensorCheck::binary_ops_ew("Lower_equal", &self, &other));
         K::lower_equal(self.primitive, other.primitive)
@@ -240,6 +251,7 @@ where
     ///
     /// The index tensor should have the same shape as the original tensor except for the dim
     /// specified.
+    #[track_caller]
     pub fn gather(self, dim: usize, indices: Tensor<B, D, Int>) -> Self {
         check!(TensorCheck::gather::<D>(
             dim,
@@ -265,6 +277,7 @@ where
     /// dimension. The value and index tensors should have the same shape.
     ///
     /// Other references to the input tensor will not be modified by this operation.
+    #[track_caller]
     pub fn scatter(self, dim: usize, indices: Tensor<B, D, Int>, values: Self) -> Self {
         check!(TensorCheck::scatter::<D>(
             dim,
@@ -283,6 +296,7 @@ where
     /// `output[i, j, k] = input[indices[i], j, k]; // dim = 0`
     /// `output[i, j, k] = input[i, indices[j], k]; // dim = 1`
     /// `output[i, j, k] = input[i, j, indices[k]]; // dim = 2`
+    #[track_caller]
     pub fn select(self, dim: usize, indices: Tensor<B, 1, Int>) -> Self {
         check!(TensorCheck::select::<D>(dim));
         Self::new(K::select(self.primitive, dim, indices))
@@ -296,6 +310,7 @@ where
     /// `input[indices[i], j, k] += values[i, j, k]; // dim = 0`
     /// `input[i, indices[j], k] += values[i, j, k]; // dim = 1`
     /// `input[i, j, indices[k]] += values[i, j, k]; // dim = 2`
+    #[track_caller]
     pub fn select_assign(
         self,
         dim: usize,
@@ -337,6 +352,7 @@ where
     }
 
     /// Find the maximum value along the given dimension.
+    #[track_caller]
     pub fn max_dim(self, dim: usize) -> Tensor<B, D, K> {
         check!(TensorCheck::aggregate_dim::<D>("Max", dim));
 
@@ -346,6 +362,7 @@ where
     /// Find the maximum value along the given dimension.
     ///
     /// Also returns the indices.
+    #[track_caller]
     pub fn max_dim_with_indices(self, dim: usize) -> (Tensor<B, D, K>, Tensor<B, D, Int>) {
         check!(TensorCheck::aggregate_dim::<D>("Max", dim));
 
@@ -382,6 +399,7 @@ where
     }
 
     /// Find the minimum value along the given dimension.
+    #[track_caller]
     pub fn min_dim(self, dim: usize) -> Tensor<B, D, K> {
         check!(TensorCheck::aggregate_dim::<D>("Min", dim));
         Tensor::new(K::min_dim(self.primitive, dim))
@@ -390,6 +408,7 @@ where
     /// Find the minimum value along the given dimension.
     ///
     /// Also returns the indices.
+    #[track_caller]
     pub fn min_dim_with_indices(self, dim: usize) -> (Tensor<B, D, K>, Tensor<B, D, Int>) {
         check!(TensorCheck::aggregate_dim::<D>("Min", dim));
 


### PR DESCRIPTION
Error messages now print the location of the reference of methods in the user's code, rather than the location of the declaration in Burn. Enabled though #[track_caller] attribute.

## Pull Request Template

### Checklist

- [X] Confirm that `run-checks` script has been executed. 
       nb: Some tests did not pass but they did so even before I did any contributions. 

### Changes

Added #[track_caller] attribute to tensor api methods and the building blocks that called them in the nn module. 
Information about the attribute can be read here: https://rustc-dev-guide.rust-lang.org/backend/implicit-caller-location.html
For it to work all methods between the panic of the check macro in burn-tensor/src/tensor/api/check.rs and the user invocation must be assigned this attribute - it is possible that I can have missed some of those. 

### Testing

No automatic testing has been done. Only tried it out manually through inducing intentional bugs in ./examples (they are not included in the pull request, naturally).
