### PR TITLE
Perf/Empty Context Cache

### DIFF
--- a/burn-wgpu/src/context/base.rs
+++ b/burn-wgpu/src/context/base.rs
@@ -32,7 +32,6 @@ pub struct Context {
     device_wgpu: Arc<wgpu::Device>,
     cache: Mutex<HashMap<TemplateKey, (Arc<ComputePipeline>, usize)>>,
     is_tuning: Mutex<bool>,
-    pipeline_counter: Mutex<HashMap<TemplateKey, usize>>,
     client: ContextClientImpl,
     pub(crate) tuner: Tuner,
     pub(crate) device: WgpuDevice,
@@ -74,7 +73,6 @@ impl Context {
             client,
             cache: Mutex::new(HashMap::new()),
             is_tuning: false.into(),
-            pipeline_counter: Mutex::new(HashMap::new()),
             tuner: Tuner::new(),
             info,
         }
@@ -258,7 +256,6 @@ impl Context {
 
     fn retain_best_kernel(&self) {
         let mut cache = self.cache.lock();
-        let counter = self.pipeline_counter.lock();
         if cache.len() == 1 {
             return;
         }
@@ -268,7 +265,7 @@ impl Context {
             .max_by(|a, b| {
                 cache
                     .get(a)
-                    .map(|(_, count_a)| count_a) 
+                    .map(|(_, count_a)| count_a)
                     .unwrap_or(&0)
                     .cmp(&cache.get(b).map(|(_, count_b)| count_b).unwrap_or(&0))
             })

--- a/burn-wgpu/src/context/base.rs
+++ b/burn-wgpu/src/context/base.rs
@@ -107,16 +107,6 @@ impl Context {
         pipeline: Arc<ComputePipeline>,
         buffers: &[&Buffer],
     ) {
-        if !self.is_tuning.load(Ordering::Relaxed) && !self.tuning_template_ids.lock().is_empty() {
-            // clean cache of pipelines accumulated during tuning
-            let mut cache = self.cache.lock();
-            let mut tuning_template_ids = self.tuning_template_ids.lock();
-            for template_id in tuning_template_ids.iter() {
-                cache.remove(template_id);
-            }
-            tuning_template_ids.clear();
-        }
-
         let group_layout = pipeline.get_bind_group_layout(0);
 
         let entries = buffers
@@ -257,6 +247,15 @@ impl Context {
 
     pub fn stop_tuning(&self) {
         self.is_tuning.store(false, Ordering::Relaxed);
+
+        // clean cache of pipelines accumulated during tuning
+        let mut cache = self.cache.lock();
+        let mut tuning_template_ids = self.tuning_template_ids.lock();
+        for template_id in tuning_template_ids.iter() {
+            cache.remove(template_id);
+        }
+
+        tuning_template_ids.clear();
     }
 }
 

--- a/burn-wgpu/src/context/base.rs
+++ b/burn-wgpu/src/context/base.rs
@@ -242,7 +242,7 @@ impl Context {
         *self.is_tuning.lock() = true;
     }
 
-    /// Let the Context know that the next ComputePipeline that is called is the 'Winning"
+    /// Let the Context know that the next ComputePipeline that is called is the 'Winning'
     /// kernel and we can get rid of the rest.
     pub fn perform_cache_optimization(&self) {
         *self.optimize_cache.lock() = true;

--- a/burn-wgpu/src/context/base.rs
+++ b/burn-wgpu/src/context/base.rs
@@ -40,11 +40,12 @@ pub struct Context {
     is_tuning: AtomicBool,
     client: ContextClientImpl,
     pub(crate) tuner: Tuner,
+    tuning_template_ids: Mutex<Vec<TemplateKey>>,
     pub(crate) device: WgpuDevice,
     pub(crate) info: wgpu::AdapterInfo,
 }
 
-#[derive(Debug, Hash, PartialOrd, PartialEq, Eq)]
+#[derive(Debug, Hash, Clone, PartialOrd, PartialEq, Eq)]
 enum TemplateKey {
     Static(TypeId),
     Dynamic(String),
@@ -80,6 +81,7 @@ impl Context {
             cache: Mutex::new(HashMap::new()),
             is_tuning: AtomicBool::new(false),
             tuner: Tuner::new(),
+            tuning_template_ids: Mutex::new(Vec::new()),
             info,
         }
     }
@@ -105,6 +107,16 @@ impl Context {
         pipeline: Arc<ComputePipeline>,
         buffers: &[&Buffer],
     ) {
+        if !self.is_tuning.load(Ordering::Relaxed) && !self.tuning_template_ids.lock().is_empty() {
+            // clean cache of template_ids accumulated during tuning
+            let mut cache = self.cache.lock();
+            let mut tuning_template_ids = self.tuning_template_ids.lock();
+            for template_id in tuning_template_ids.iter() {
+                cache.remove(template_id);
+            }
+            tuning_template_ids.clear();
+        }
+
         let group_layout = pipeline.get_bind_group_layout(0);
 
         let entries = buffers
@@ -190,10 +202,12 @@ impl Context {
         let source = K::source_template();
         let pipeline = self.compile_source(&source.complete());
 
-        if !self.is_tuning.load(Ordering::Relaxed) {
-            cache.insert(template_id, pipeline.clone());
+        if self.is_tuning.load(Ordering::Relaxed) {
+            let mut templates_vec = self.tuning_template_ids.lock();
+            templates_vec.push(template_id.clone());
         }
 
+        cache.insert(template_id, pipeline.clone());
         pipeline
     }
 
@@ -209,10 +223,12 @@ impl Context {
         let source = kernel.source_template();
         let pipeline = self.compile_source(&source.complete());
 
-        if !self.is_tuning.load(Ordering::Relaxed) {
-            cache.insert(template_id, pipeline.clone());
+        if self.is_tuning.load(Ordering::Relaxed) {
+            let mut templates_vec = self.tuning_template_ids.lock();
+            templates_vec.push(template_id.clone());
         }
 
+        cache.insert(template_id, pipeline.clone());
         pipeline
     }
 

--- a/burn-wgpu/src/context/base.rs
+++ b/burn-wgpu/src/context/base.rs
@@ -108,7 +108,7 @@ impl Context {
         buffers: &[&Buffer],
     ) {
         if !self.is_tuning.load(Ordering::Relaxed) && !self.tuning_template_ids.lock().is_empty() {
-            // clean cache of template_ids accumulated during tuning
+            // clean cache of pipelines accumulated during tuning
             let mut cache = self.cache.lock();
             let mut tuning_template_ids = self.tuning_template_ids.lock();
             for template_id in tuning_template_ids.iter() {

--- a/burn-wgpu/src/kernel/matmul/tune.rs
+++ b/burn-wgpu/src/kernel/matmul/tune.rs
@@ -263,7 +263,7 @@ where
 
             context
                 .tuner
-                .tune(id, (lhs, rhs), tunables, &context.device)
+                .tune(id, (lhs, rhs), tunables, &context.device, &context)
         }
     };
 

--- a/burn-wgpu/src/tune/base.rs
+++ b/burn-wgpu/src/tune/base.rs
@@ -130,6 +130,7 @@ impl Tuner {
         input: I,
         tunables: Vec<Tunable<G, I, O>>,
         device: &WgpuDevice,
+        context: &Context,
     ) -> O
     where
         I: Send + Sync + 'static,
@@ -137,10 +138,12 @@ impl Tuner {
     {
         let mut cache = self.cache.write().unwrap();
 
+        context.start_tuning();
         let results = benchmark(&tunables, device);
         let kernel = find_best(&id, tunables, results);
         cache.insert(id.clone(), kernel);
         drop(cache);
+        context.end_tuning();
 
         match self.execute(&id, input) {
             Execution::Executed(output) => output,

--- a/burn-wgpu/src/tune/base.rs
+++ b/burn-wgpu/src/tune/base.rs
@@ -143,8 +143,7 @@ impl Tuner {
         let kernel = find_best(&id, tunables, results);
         cache.insert(id.clone(), kernel);
         drop(cache);
-
-        context.perform_cache_optimization();
+        context.stop_tuning();
 
         match self.execute(&id, input) {
             Execution::Executed(output) => output,

--- a/burn-wgpu/src/tune/base.rs
+++ b/burn-wgpu/src/tune/base.rs
@@ -143,7 +143,8 @@ impl Tuner {
         let kernel = find_best(&id, tunables, results);
         cache.insert(id.clone(), kernel);
         drop(cache);
-        context.end_tuning();
+
+        context.perform_cache_optimization();
 
         match self.execute(&id, input) {
             Execution::Executed(output) => output,


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [ ] Confirm that `run-checks` script has been executed.
-  Currently on Windows and ran into this issue: https://github.com/rust-lang/cargo/issues/11544, but ran `clippy` and `cargo fmt`

### Related Issues/PRs

https://github.com/burn-rs/burn/issues/619

### Changes

@louisfd This is a pretty brute-force method that relies on a potentially flawed assumption that I'd love to get your thoughts on. What I did is add an `is_tuning` flag to the `Context` that gets turned on by the `Tuner`'s `tune()` method, which tells the `Context` to explicitly tag the kernel that's being executed with a count each execution. After the benchmarks are run, the `Tuner` turns on another flag, `optimize_cache`, that signals to the `Context` that the next kernel that is run is the "winning" kernel. The latter part is where I'm a bit concerned. I assume that the **only** ComputePipeline used post-tuning is the winner, so the next execution will serve as confirmation of it being the fastest and all others can be cleared. 

I also considered cache timestamping or more direct Tuner-Context communication, but I wanted to refrain from additional cache management overhead/tighter coupling between the Tuner and Context. 

### Testing

_Describe how these changes have been tested._
TBD