### PR TITLE
fix(book): use the correct burn versions

### DIFF
--- a/burn-book/src/basic-workflow/model.md
+++ b/burn-book/src/basic-workflow/model.md
@@ -10,11 +10,11 @@ edition = "2021"
 name = "My first Burn model"
 
 [dependencies]
-burn = "0.8"
-burn-wgpu = "0.8"
-burn-dataset = "0.8"
-burn-autodiff = "0.8"
-burn-train = "0.8"
+burn = "0.9"
+burn-wgpu = "0.9"
+burn-dataset = "0.9"
+burn-autodiff = "0.9"
+burn-train = "0.9"
 
 # Serialization
 serde = "1"


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirm that `run-checks` script has been executed.

### Related Issues/PRs

N/A

### Changes

`AdaptiveAvgPool2d` and `AdaptiveAvgPool2dConfig` are unavailable in version `0.8` but in `0.9`. 

### Testing

Scripts
