### PR TITLE
Do not use default device when running kernel::matmul::tune

### DIFF
--- a/burn-wgpu/src/kernel/matmul/tune.rs
+++ b/burn-wgpu/src/kernel/matmul/tune.rs
@@ -216,14 +216,16 @@ where
     }
 
     fn prepare(&self, device: &WgpuDevice) -> Self::Args {
-        let lhs = Tensor::<WgpuBackend<G, E, i32>, D>::random(
+        let lhs = Tensor::<WgpuBackend<G, E, i32>, D>::random_device(
             self.shape_lhs.clone(),
             Distribution::Default,
+            device,
         )
         .to_device(device);
-        let rhs = Tensor::<WgpuBackend<G, E, i32>, D>::random(
+        let rhs = Tensor::<WgpuBackend<G, E, i32>, D>::random_device(
             self.shape_rhs.clone(),
             Distribution::Default,
+            device,
         )
         .to_device(device);
 


### PR DESCRIPTION
### Checklist

`run-checks.sh` not runned because of error downloading pytorch (sorry).

### Changes

Do not use default device when running kernel::matmul::tune. Use the device of the involved Tensor instead of Device::default.

Without this change the bellow program fail on my hardware because my discrete card is too old and not fully Vulkan compatible.

### Testing
Cargo.toml:

```toml
burn-wgpu = { path = "/path/to/burn/burn-wgpu", features=["autotune"] }
```

Code sniped
```
type Backend = WgpuBackend<Vulkan, f32, i32>;
let device = WgpuDevice::Cpu;
let ta: Tensor<Backend, 2, Float> = Tensor::from_data_device(burn_tensor::Data {
    value: vec![0.],
    shape: burn_tensor::Shape::new([1,1]),
}, &device);
let tb = Tensor::from_data_device(burn_tensor::Data {
    value: vec![0.],
    shape: burn_tensor::Shape::new([1,1]),
}, &device);
ta.matmul(tb);
```