### PR TITLE
Feat/configurable initializers for transformer-family modules

### DIFF
--- a/burn-core/src/nn/transformer/encoder.rs
+++ b/burn-core/src/nn/transformer/encoder.rs
@@ -3,7 +3,7 @@ use burn_tensor::Bool;
 
 use crate::{
     self as burn,
-    nn::{attention::MhaCache, cache::TensorCache},
+    nn::{attention::MhaCache, cache::TensorCache, Initializer},
 };
 
 use super::{PositionWiseFeedForward, PositionWiseFeedForwardConfig};
@@ -34,6 +34,11 @@ pub struct TransformerEncoderConfig {
     /// Layer norm will be applied first instead of after the other modules.
     #[config(default = false)]
     pub norm_first: bool,
+    /// The type of function used to initialize neural network parameters
+    #[config(
+        default = "Initializer::KaimingUniform{gain:1.0/libm::sqrt(3.0), fan_out_only:false}"
+    )]
+    pub initializer: Initializer,
 }
 
 /// The transformer encoder module as describe in the paper [Attention Is All You Need](https://arxiv.org/abs/1706.03762).
@@ -168,12 +173,14 @@ impl<B: Backend> TransformerEncoderLayer<B> {
         record: TransformerEncoderLayerRecord<B>,
     ) -> Self {
         let mha = MultiHeadAttentionConfig::new(config.d_model, config.n_heads)
+            .with_initializer(config.initializer.clone())
             .with_dropout(config.dropout)
             .init_with(record.mha);
         let norm_1 = LayerNormConfig::new(config.d_model).init_with(record.norm_1);
         let norm_2 = LayerNormConfig::new(config.d_model).init_with(record.norm_2);
         let dropout = DropoutConfig::new(config.dropout).init();
         let pwff = PositionWiseFeedForwardConfig::new(config.d_model, config.d_ff)
+            .with_initializer(config.initializer.clone())
             .with_dropout(config.dropout)
             .init_with(record.pwff);
 
@@ -188,12 +195,14 @@ impl<B: Backend> TransformerEncoderLayer<B> {
     }
     fn new(config: &TransformerEncoderConfig) -> Self {
         let mha = MultiHeadAttentionConfig::new(config.d_model, config.n_heads)
+            .with_initializer(config.initializer.clone())
             .with_dropout(config.dropout)
             .init();
         let norm_1 = LayerNormConfig::new(config.d_model).init();
         let norm_2 = LayerNormConfig::new(config.d_model).init();
         let dropout = DropoutConfig::new(config.dropout).init();
         let pwff = PositionWiseFeedForwardConfig::new(config.d_model, config.d_ff)
+            .with_initializer(config.initializer.clone())
             .with_dropout(config.dropout)
             .init();
 


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirm that `run-checks` script has been executed.

### Changes

Parameters for transformer-family modules (`MultiHeadAttention`, `TransformerEncoder`, `TransformerDecoder`, and `PositionWiseFeedForward`) can now be initialized with any burn `Initializer`.

### Testing

Run checks.
