### PR TITLE
Feat: Some tweaks to make it more practical to integrate in a GUI app

### DIFF
--- a/burn-train/src/learner/builder.rs
+++ b/burn-train/src/learner/builder.rs
@@ -3,7 +3,7 @@ use super::Learner;
 use crate::checkpoint::{AsyncCheckpointer, Checkpointer, FileCheckpointer};
 use crate::logger::{FileMetricLogger, MetricLogger};
 use crate::metric::dashboard::cli::CLIDashboardRenderer;
-use crate::metric::dashboard::Dashboard;
+use crate::metric::dashboard::{Dashboard, DashboardRenderer, MetricWrapper, Metrics};
 use crate::metric::{Adaptor, Metric, Numeric};
 use crate::AsyncTrainerCallback;
 use burn_core::lr_scheduler::LRScheduler;
@@ -24,7 +24,6 @@ where
     O: Optimizer<M, B>,
     S: LRScheduler,
 {
-    dashboard: Dashboard<T, V>,
     checkpointer_model: Option<Arc<dyn Checkpointer<M::Record> + Send + Sync>>,
     checkpointer_optimizer: Option<Arc<dyn Checkpointer<O::Record> + Send + Sync>>,
     checkpointer_scheduler: Option<Arc<dyn Checkpointer<S::Record> + Send + Sync>>,
@@ -33,6 +32,10 @@ where
     directory: String,
     grad_accumulation: Option<usize>,
     devices: Vec<B::Device>,
+    metric_logger_train: Option<Box<dyn MetricLogger + 'static>>,
+    metric_logger_valid: Option<Box<dyn MetricLogger + 'static>>,
+    renderer: Option<Box<dyn DashboardRenderer + 'static>>,
+    metrics: Metrics<T, V>,
 }
 
 impl<B, T, V, Model, Optim, LR> LearnerBuilder<B, T, V, Model, Optim, LR>
@@ -50,12 +53,7 @@ where
     ///
     /// * `directory` - The directory to save the checkpoints.
     pub fn new(directory: &str) -> Self {
-        let renderer = Box::new(CLIDashboardRenderer::new());
-        let logger_train = Box::new(FileMetricLogger::new(format!("{directory}/train").as_str()));
-        let logger_valid = Box::new(FileMetricLogger::new(format!("{directory}/valid").as_str()));
-
         Self {
-            dashboard: Dashboard::new(renderer, logger_train, logger_valid),
             num_epochs: 1,
             checkpoint: None,
             checkpointer_model: None,
@@ -64,6 +62,10 @@ where
             directory: directory.to_string(),
             grad_accumulation: None,
             devices: vec![B::Device::default()],
+            metric_logger_train: None,
+            metric_logger_valid: None,
+            metrics: Metrics::new(),
+            renderer: None,
         }
     }
 
@@ -78,8 +80,21 @@ where
         MT: MetricLogger + 'static,
         MV: MetricLogger + 'static,
     {
-        self.dashboard
-            .replace_loggers(Box::new(logger_train), Box::new(logger_valid));
+        self.metric_logger_train = Some(Box::new(logger_train));
+        self.metric_logger_valid = Some(Box::new(logger_valid));
+        self
+    }
+
+    /// Replace the default CLI renderer with a custom one.
+    ///
+    /// # Arguments
+    ///
+    /// * `renderer` - The custom renderer.
+    pub fn renderer<DR>(mut self, renderer: DR) -> Self
+    where
+        DR: DashboardRenderer + 'static,
+    {
+        self.renderer = Some(Box::new(renderer));
         self
     }
 
@@ -88,7 +103,9 @@ where
     where
         T: Adaptor<M::Input>,
     {
-        self.dashboard.register_train(metric);
+        self.metrics
+            .train
+            .push(Box::new(MetricWrapper::new(metric)));
         self
     }
 
@@ -97,7 +114,9 @@ where
     where
         V: Adaptor<M::Input>,
     {
-        self.dashboard.register_valid(metric);
+        self.metrics
+            .valid
+            .push(Box::new(MetricWrapper::new(metric)));
         self
     }
 
@@ -128,7 +147,9 @@ where
         M: Metric + Numeric + 'static,
         T: Adaptor<M::Input>,
     {
-        self.dashboard.register_train_plot(metric);
+        self.metrics
+            .train_numeric
+            .push(Box::new(MetricWrapper::new(metric)));
         self
     }
 
@@ -143,7 +164,9 @@ where
     where
         V: Adaptor<M::Input>,
     {
-        self.dashboard.register_valid_plot(metric);
+        self.metrics
+            .valid_numeric
+            .push(Box::new(MetricWrapper::new(metric)));
         self
     }
 
@@ -211,7 +234,19 @@ where
         LR::Record: 'static,
     {
         self.init_logger();
-        let callback = Box::new(self.dashboard);
+
+        let renderer = self
+            .renderer
+            .unwrap_or_else(|| Box::new(CLIDashboardRenderer::new()));
+        let directory = &self.directory;
+        let logger_train = self.metric_logger_train.unwrap_or_else(|| {
+            Box::new(FileMetricLogger::new(format!("{directory}/train").as_str()))
+        });
+        let logger_valid = self.metric_logger_valid.unwrap_or_else(|| {
+            Box::new(FileMetricLogger::new(format!("{directory}/valid").as_str()))
+        });
+        let dashboard = Dashboard::new(renderer, self.metrics, logger_train, logger_valid);
+        let callback = Box::new(dashboard);
         let callback = Box::new(AsyncTrainerCallback::new(callback));
 
         let checkpointer_optimizer = match self.checkpointer_optimizer {

--- a/burn-train/src/learner/builder.rs
+++ b/burn-train/src/learner/builder.rs
@@ -36,6 +36,7 @@ where
     metric_logger_valid: Option<Box<dyn MetricLogger + 'static>>,
     renderer: Option<Box<dyn DashboardRenderer + 'static>>,
     metrics: Metrics<T, V>,
+    log_to_file: bool,
 }
 
 impl<B, T, V, Model, Optim, LR> LearnerBuilder<B, T, V, Model, Optim, LR>
@@ -66,6 +67,7 @@ where
             metric_logger_valid: None,
             metrics: Metrics::new(),
             renderer: None,
+            log_to_file: true,
         }
     }
 
@@ -188,6 +190,14 @@ where
         self
     }
 
+    /// By default, Rust logs are captured and written into
+    /// `experiment.log`. If disabled, standard Rust log handling
+    /// will apply.
+    pub fn log_to_file(mut self, enabled: bool) -> Self {
+        self.log_to_file = enabled;
+        self
+    }
+
     /// Register a checkpointer that will save the [optimizer](Optimizer) and the
     /// [model](ADModule).
     ///
@@ -233,8 +243,9 @@ where
         Optim::Record: 'static,
         LR::Record: 'static,
     {
-        self.init_logger();
-
+        if self.log_to_file {
+            self.init_logger();
+        }
         let renderer = self
             .renderer
             .unwrap_or_else(|| Box::new(CLIDashboardRenderer::new()));

--- a/burn-train/src/metric/base.rs
+++ b/burn-train/src/metric/base.rs
@@ -69,7 +69,7 @@ pub trait Numeric {
 }
 
 /// Data type that contains the current state of a metric at a given time.
-#[derive(new)]
+#[derive(new, Debug)]
 pub struct MetricEntry {
     /// The name of the metric.
     pub name: String,


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirm that `run-checks` script has been executed.

Those wgpu tests sure are heavy! A few of them failed for me, but I presume that's some issue with my gpu/driver.

```
---- tests::aggregation::tests::test_should_mean stdout ----
thread 'tests::aggregation::tests::test_should_mean' panicked at 'assertion failed: `(left == right)`
  left: `Data { value: [2.4999998], shape: Shape { dims: [1] } }`,
   right: `Data { value: [2.5], shape: Shape { dims: [1] } }`', burn-wgpu/src/lib.rs:47:5

---- tests::aggregation::tests::test_should_mean_last_dim stdout ----
thread 'tests::aggregation::tests::test_should_mean_last_dim' panicked at 'assertion failed: `(left == right)`
  left: `Data { value: [0.99999994, 3.9999998], shape: Shape { dims: [2, 1] } }`,
   right: `Data { value: [1.0, 4.0], shape: Shape { dims: [2, 1] } }`', burn-wgpu/src/lib.rs:47:5

---- tests::div::tests::should_support_div_ops stdout ----
thread 'tests::div::tests::should_support_div_ops' panicked at 'assertion failed: `(left == right)`
  left: `Data { value: [0.0, 1.0, 1.0, 1.0, 1.0, 1.0], shape: Shape { dims: [2, 3] } }`,
   right: `Data { value: [0.0, 1.0, 1.0, 0.99999994, 1.0, 1.0], shape: Shape { dims: [2, 3] } }`', burn-wgpu/src/lib.rs:47:5


failures:
    tests::aggregation::tests::test_should_mean
    tests::aggregation::tests::test_should_mean_last_dim
    tests::div::tests::should_support_div_ops
```

### Related Issues/PRs

https://github.com/open-spaced-repetition/fsrs-optimizer-burn/issues/27

### Changes

Both commits are aimed at making it easier to use burn in a GUI app. The first allows opting out of the default CLI renderer, and the second allows us to avoid creating large files on disk when the code happens to have some info!() calls in the training path.

### Testing

The standard tests pass, and I tried a branch of our code that uses these options.
