### PR TITLE
Fix: processed count was one greater than total items at completion

### DIFF
--- a/burn-core/src/data/dataloader/batch.rs
+++ b/burn-core/src/data/dataloader/batch.rs
@@ -120,14 +120,8 @@ impl<I, O> Iterator for BatchDataloaderIterator<I, O> {
     type Item = O;
 
     fn next(&mut self) -> Option<O> {
-        loop {
-            let item = self.dataset.get(self.current_index);
+        while let Some(item) = self.dataset.get(self.current_index) {
             self.current_index += 1;
-
-            let item = match item {
-                Some(item) => item,
-                None => break,
-            };
             self.strategy.add(item);
 
             if let Some(items) = self.strategy.batch(false) {


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirm that `run-checks` script has been executed.

### Changes

At the end of training, the processed count was one greater than the total count. By doing the increment
after the loop exit check, this is avoided.

### Testing

Standard tests, and manual observation that it performs correctly now.