### PR TITLE
Allow opting out of SQLite support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,11 +47,11 @@ proc-macro2 = "1.0.60"
 protobuf-codegen = "3.2"
 quote = "1.0.28"
 r2d2 = "0.8.10"
-r2d2_sqlite = {version = "0.22.0", features = ["bundled"]}
+r2d2_sqlite = {version = "0.22.0"}
 rayon = "1.7.0"
 rmp-serde = "1.1.1"
 rstest = "0.18.1"
-rusqlite = {version = "0.29", features = ["bundled-full"]}
+rusqlite = {version = "0.29"}
 sanitize-filename = "0.5.0"
 serde_rusqlite = "0.33.1"
 spin = {version = "0.9.8", features = ["mutex", "spin_mutex"]}

--- a/burn-core/Cargo.toml
+++ b/burn-core/Cargo.toml
@@ -43,7 +43,7 @@ burn-autodiff = { path = "../burn-autodiff", version = "0.9.0", optional = true,
   "export_tests",
 ] }
 burn-common = { path = "../burn-common", version = "0.9.0", default-features = false }
-burn-dataset = { path = "../burn-dataset", version = "0.9.0", default-features = false, optional = true }
+burn-dataset = { path = "../burn-dataset", version = "0.9.0", optional = true }
 burn-derive = { path = "../burn-derive", version = "0.9.0" }
 burn-tensor = { path = "../burn-tensor", version = "0.9.0", default-features = false }
 

--- a/burn-dataset/Cargo.toml
+++ b/burn-dataset/Cargo.toml
@@ -13,6 +13,7 @@ version = "0.9.0"
 [features]
 default = [
   "fake",
+  "sqlite-bundled"
 ]
 
 audio = [
@@ -20,6 +21,12 @@ audio = [
 ]
 
 fake = ["dep:fake"]
+
+sqlite = ["__sqlite-shared", "dep:rusqlite"]
+sqlite-bundled = ["__sqlite-shared", "rusqlite/bundled"]
+
+# internal
+__sqlite-shared = ["dep:r2d2", "dep:r2d2_sqlite", "dep:serde_rusqlite"]
 
 [dependencies]
 csv = {workspace = true}
@@ -29,15 +36,15 @@ fake = {workspace = true, optional = true}
 gix-tempfile = {workspace = true}
 hound = {version = "3.5.0", optional = true}
 image = {version = "0.24.6", features = ["png"]}
-r2d2 = {workspace = true}
-r2d2_sqlite = {workspace = true}
+r2d2 = {workspace = true, optional = true}
+r2d2_sqlite = {workspace = true, optional = true}
 rand = {workspace = true, features = ["std"]}
 rmp-serde = {workspace = true}
-rusqlite = {workspace = true}
+rusqlite = {workspace = true, optional = true}
 sanitize-filename = {workspace = true}
 serde = {workspace = true, features = ["std", "derive"]}
 serde_json = {workspace = true, features = ["std"]}
-serde_rusqlite = {workspace = true}
+serde_rusqlite = {workspace = true, optional = true}
 strum = {workspace = true}
 strum_macros = {workspace = true}
 tempfile = {workspace = true}

--- a/burn-dataset/src/dataset/mod.rs
+++ b/burn-dataset/src/dataset/mod.rs
@@ -3,6 +3,7 @@ mod base;
 mod fake;
 mod in_memory;
 mod iterator;
+#[cfg(any(feature = "sqlite", feature = "sqlite-bundled"))]
 mod sqlite;
 
 #[cfg(feature = "fake")]
@@ -10,4 +11,5 @@ pub use self::fake::*;
 pub use base::*;
 pub use in_memory::*;
 pub use iterator::*;
+#[cfg(any(feature = "sqlite", feature = "sqlite-bundled"))]
 pub use sqlite::*;

--- a/burn-dataset/src/lib.rs
+++ b/burn-dataset/src/lib.rs
@@ -21,6 +21,7 @@ pub mod audio;
 
 mod dataset;
 pub use dataset::*;
+#[cfg(any(feature = "sqlite", feature = "sqlite-bundled"))]
 pub use source::huggingface::downloader::*;
 
 #[cfg(test)]

--- a/burn-dataset/src/source/mod.rs
+++ b/burn-dataset/src/source/mod.rs
@@ -1,2 +1,3 @@
 /// Huggingface source
+#[cfg(any(feature = "sqlite", feature = "sqlite-bundled"))]
 pub mod huggingface;


### PR DESCRIPTION
burn-dataset includes a bundled copy of SQLite by default, which proves problematic - it doesn't allow us to use a system libsqlite if we'd like, and our usage of 'bundled' conflicts with burn-dataset's usage of 'bundled-full', resulting in databases that can't be opened.

Rusqlite's docs have the following to say:

 `bundled` causes us to automatically compile and link in an up to date
 version of SQLite for you. This avoids many common build issues, and
 avoids depending on the version of SQLite on the users system (or your
 system), which may be old or missing. It's the right choice for most
 programs that control their own SQLite databases.

 That said, it's not ideal for all scenarios and in particular, generic
 libraries built around `rusqlite` should probably not enable it, which
 is why it is not a default feature -- it could become hard to disable.

I've assumed you'd like to keep this functionality on by default, so I've just added a feature flag so that we can opt out of it.

## Pull Request Template

### Checklist

- [x] Confirm that `run-checks` script has been executed.

### Testing

Standard tests, and confirmed this fixes the problem for us.