### PR TITLE
Fix: ensure final CLI update happens

### DIFF
--- a/burn-train/src/metric/dashboard/cli.rs
+++ b/burn-train/src/metric/dashboard/cli.rs
@@ -17,6 +17,12 @@ pub struct CLIDashboardRenderer {
     metric_valid_plot: HashMap<String, TextPlot>,
 }
 
+impl TrainingProgress {
+    fn finished(&self) -> bool {
+        self.epoch == self.epoch_total && self.progress.items_processed == self.progress.items_total
+    }
+}
+
 impl Default for CLIDashboardRenderer {
     fn default() -> Self {
         CLIDashboardRenderer::new()
@@ -193,10 +199,11 @@ impl CLIDashboardRenderer {
     }
 
     fn render(&mut self) {
-        if std::time::Instant::now()
-            .duration_since(self.last_update)
-            .as_millis()
-            < MAX_REFRESH_RATE_MILLIS
+        if !self.progress.finished()
+            && std::time::Instant::now()
+                .duration_since(self.last_update)
+                .as_millis()
+                < MAX_REFRESH_RATE_MILLIS
         {
             return;
         }


### PR DESCRIPTION
The merge of #708 unearthed a bug in the CLI code: if at completion time the update is within the throttling period, you can end up with a final output that appears as if the process didn't fully complete.

More info: https://github.com/open-spaced-repetition/fsrs-optimizer-burn/pull/36#issuecomment-1696736807

## Pull Request Template

### Checklist

- [x] Confirm that `run-checks` script has been executed.
