### PR TITLE
Disable fake dataset by default

### DIFF
--- a/burn-dataset/Cargo.toml
+++ b/burn-dataset/Cargo.toml
@@ -12,7 +12,6 @@ version = "0.9.0"
 
 [features]
 default = [
-  "fake",
   "sqlite-bundled"
 ]
 
@@ -53,3 +52,4 @@ thiserror = {workspace = true}
 [dev-dependencies]
 rayon = {workspace = true}
 rstest = {workspace = true}
+fake = {workspace = true}

--- a/burn-dataset/src/dataset/mod.rs
+++ b/burn-dataset/src/dataset/mod.rs
@@ -1,5 +1,5 @@
 mod base;
-#[cfg(feature = "fake")]
+#[cfg(any(test, feature = "fake"))]
 mod fake;
 mod in_memory;
 mod iterator;


### PR DESCRIPTION
@antimora @dae Just removing fake from the list of default features following the recent change with the sqlite feature flag. https://github.com/burn-rs/burn/pull/711