### PR TITLE
Fix: burn-core/std depended on sqlite feature

### DIFF
--- a/burn-core/Cargo.toml
+++ b/burn-core/Cargo.toml
@@ -43,7 +43,7 @@ burn-autodiff = { path = "../burn-autodiff", version = "0.9.0", optional = true,
   "export_tests",
 ] }
 burn-common = { path = "../burn-common", version = "0.9.0", default-features = false }
-burn-dataset = { path = "../burn-dataset", version = "0.9.0", optional = true }
+burn-dataset = { path = "../burn-dataset", version = "0.9.0", optional = true, default-features = false }
 burn-derive = { path = "../burn-derive", version = "0.9.0" }
 burn-tensor = { path = "../burn-tensor", version = "0.9.0", default-features = false }
 

--- a/burn-core/Cargo.toml
+++ b/burn-core/Cargo.toml
@@ -15,7 +15,7 @@ default = ["std"]
 std = [
   "burn-autodiff",
   "burn-common/std",
-  "burn-dataset",
+  "dataset",
   "burn-tensor/std",
   "burn-ndarray/std",
   "flate2",
@@ -27,6 +27,10 @@ std = [
   "bincode/std",
   "half/std",
 ]
+
+dataset = ["burn-dataset"]
+dataset-sqlite = ["burn-dataset/sqlite"]
+dataset-sqlite-bundled = ["burn-dataset/sqlite-bundled"]
 
 # Serialization formats
 experimental-named-tensor = ["burn-tensor/experimental-named-tensor"]

--- a/burn-dataset/Cargo.toml
+++ b/burn-dataset/Cargo.toml
@@ -11,9 +11,7 @@ repository = "https://github.com/burn-rs/burn/tree/main/burn-dataset"
 version = "0.9.0"
 
 [features]
-default = [
-  "sqlite-bundled"
-]
+default = []
 
 audio = [
   "hound",

--- a/burn/Cargo.toml
+++ b/burn/Cargo.toml
@@ -17,9 +17,10 @@ std = [
   "burn-core/std",
 ]
 train = ["std", "burn-train"] # Training requires std
-dataset = ["burn-dataset"]
-dataset-sqlite = ["burn-dataset/sqlite"]
-dataset-sqlite-bundled = ["burn-dataset/sqlite-bundled"]
+
+dataset = ["burn-core/dataset"]
+dataset-sqlite = ["burn-core/dataset-sqlite"]
+dataset-sqlite-bundled = ["burn-core/dataset-sqlite-bundled"]
 
 [dependencies]
 
@@ -27,4 +28,3 @@ dataset-sqlite-bundled = ["burn-dataset/sqlite-bundled"]
 
 burn-core = {path = "../burn-core", version = "0.9.0", default-features = false}
 burn-train = {path = "../burn-train", version = "0.9.0", optional = true}
-burn-dataset = {path = "../burn-dataset", version = "0.9.0", optional = true, default-features = false }

--- a/burn/Cargo.toml
+++ b/burn/Cargo.toml
@@ -17,6 +17,9 @@ std = [
   "burn-core/std",
 ]
 train = ["std", "burn-train"] # Training requires std
+dataset = ["burn-dataset"]
+dataset-sqlite = ["burn-dataset/sqlite"]
+dataset-sqlite-bundled = ["burn-dataset/sqlite-bundled"]
 
 [dependencies]
 
@@ -24,3 +27,4 @@ train = ["std", "burn-train"] # Training requires std
 
 burn-core = {path = "../burn-core", version = "0.9.0", default-features = false}
 burn-train = {path = "../burn-train", version = "0.9.0", optional = true}
+burn-dataset = {path = "../burn-dataset", version = "0.9.0", optional = true, default-features = false }

--- a/examples/guide/Cargo.toml
+++ b/examples/guide/Cargo.toml
@@ -6,6 +6,9 @@ name = "guide"
 publish = false
 version = "0.9.0"
 
+[features]
+default = ["burn/dataset-sqlite-bundled"]
+
 [dependencies]
 burn = {path = "../../burn"}
 burn-autodiff = {path = "../../burn-autodiff"}

--- a/examples/mnist/Cargo.toml
+++ b/examples/mnist/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 version = "0.9.0"
 
 [features]
-default = []
+default = ["burn/dataset-sqlite-bundled"]
 ndarray = ["burn-ndarray"]
 ndarray-blas-accelerate = ["burn-ndarray/blas-accelerate"]
 ndarray-blas-netlib = ["burn-ndarray/blas-netlib"]

--- a/examples/onnx-inference/Cargo.toml
+++ b/examples/onnx-inference/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 version = "0.9.0"
 
 [features]
-default = []
+default = ["burn/dataset-sqlite-bundled"]
 
 [dependencies]
 burn = {path = "../../burn"}

--- a/examples/text-classification/Cargo.toml
+++ b/examples/text-classification/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 version = "0.9.0"
 
 [features]
+default = ["burn/dataset-sqlite-bundled"]
 f16 = []
 ndarray = ["burn-ndarray"]
 ndarray-blas-accelerate = ["burn-ndarray/blas-accelerate"]

--- a/examples/text-generation/Cargo.toml
+++ b/examples/text-generation/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 version = "0.9.0"
 
 [features]
-default = []
+default = ["burn/dataset-sqlite-bundled"]
 f16 = []
 
 [dependencies]

--- a/run-checks.ps1
+++ b/run-checks.ps1
@@ -9,8 +9,8 @@
 # - `std` to perform checks using `libstd`
 # - `no_std` to perform checks on an embedded environment using `libcore`
 # - `typos` to check for typos in the codebase
-#
-# If no `environment` value has been passed, run all checks.
+# - `examples` to check the examples compile
+# If no `environment` value has been passed, run all checks except examples.
 
 # Exit if any command fails
 $ErrorActionPreference = "Stop"

--- a/run-checks.sh
+++ b/run-checks.sh
@@ -14,8 +14,9 @@ set -e
 # - `std` to perform checks using `libstd`
 # - `no_std` to perform checks on an embedded environment using `libcore`
 # - `typos` to check for typos in the codebase
+# - `examples` to check the examples compile
 #
-# If no `environment` value has been passed, run all checks.
+# If no `environment` value has been passed, run all checks except examples.
 
 # Compile run-checks binary
 rustc scripts/run-checks.rs --crate-type bin --out-dir scripts

--- a/scripts/run-checks.rs
+++ b/scripts/run-checks.rs
@@ -277,7 +277,13 @@ fn check_examples() {
 
     std::fs::read_dir("examples").unwrap().for_each(|dir| {
         let dir = dir.unwrap();
-        println!("Checking {} \n\n", dir.path().display());
+        let path = dir.path();
+        if path.file_name().unwrap().to_str().unwrap() == "notebook" {
+            // not a crate
+            return;
+        }
+        let path = path.to_str().unwrap();
+        println!("Checking {path} \n\n");
 
         let child = Command::new("cargo")
             .arg("check")

--- a/scripts/run-checks.rs
+++ b/scripts/run-checks.rs
@@ -16,6 +16,7 @@
 //!     - `std` to perform checks using `libstd`
 //!     - `no_std` to perform checks on an embedded environment using `libcore`
 //!     - `typos` to check typos in the source code
+//!     - `examples` to check the examples compile
 
 use std::env;
 use std::process::{Child, Command, Stdio};
@@ -271,6 +272,27 @@ fn check_typos() {
     handle_child_process(typos, "Failed to wait for typos child process");
 }
 
+fn check_examples() {
+    println!("Checking examples compile \n\n");
+
+    std::fs::read_dir("examples").unwrap().for_each(|dir| {
+        let dir = dir.unwrap();
+        println!("Checking {} \n\n", dir.path().display());
+
+        let child = Command::new("cargo")
+            .arg("check")
+            .current_dir(dir.path())
+            .stdout(Stdio::inherit()) // Send stdout directly to terminal
+            .stderr(Stdio::inherit()) // Send stderr directly to terminal
+            .spawn()
+            .expect("Failed to check examples");
+
+        // Handle typos child process
+        handle_child_process(child, "Failed to wait for examples child process");
+    });
+}
+
+
 fn main() {
     // Start time measurement
     let start = Instant::now();
@@ -290,6 +312,7 @@ fn main() {
         Some("std") => std_checks(),
         Some("no_std") => no_std_checks(),
         Some("typos") => check_typos(),
+        Some("examples") => check_examples(),
         Some(_) | None => {
             /* Run all checks */
             check_typos();


### PR DESCRIPTION
burn-train depends on burn-core with default features, so importing burn-train results in sqlite being included even if you'd explicitly excluded the default features from a direct burn-dataset import.

## Pull Request Template

### Checklist

- [x] Confirm that `run-checks` script has been executed.
