### PR TITLE
Migrate from log4rs to tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ hashbrown = "0.14.0"
 indicatif = "0.17.5"
 libm = "0.2.7"
 log = "0.4.19"
-log4rs = "1.2.0"
 pretty_assertions = "1.3"
 proc-macro2 = "1.0.60"
 protobuf-codegen = "3.2"
@@ -60,6 +59,9 @@ strum_macros = "0.24"
 syn = {version = "2.0", features = ["full", "extra-traits"]}
 tempfile = "3.6.0"
 thiserror = "1.0.40"
+tracing-subscriber = "0.3.17"
+tracing-core = "0.1.31"
+tracing-appender = "0.2.2"
 
 # WGPU stuff
 futures-intrusive = "0.5"

--- a/burn-import/Cargo.toml
+++ b/burn-import/Cargo.toml
@@ -25,7 +25,6 @@ bytemuck = {workspace = true}
 derive-new = {workspace = true}
 half = {workspace = true}
 log = {workspace = true}
-log4rs = {workspace = true}
 proc-macro2 = {workspace = true}
 protobuf = {version = "3.2", features = ["with-bytes"]}
 quote = {workspace = true}
@@ -35,6 +34,8 @@ serde_json = {workspace = true, features = ["std"]}
 strum = {workspace = true}
 strum_macros = {workspace = true}
 syn = {workspace = true, features = ["parsing"]}
+tracing-subscriber.workspace = true
+tracing-core.workspace = true
 
 [build-dependencies]
 protobuf-codegen = {workspace = true}

--- a/burn-import/src/logger.rs
+++ b/burn-import/src/logger.rs
@@ -1,26 +1,14 @@
-use log::{LevelFilter, SetLoggerError};
-use log4rs::{
-    append::console::ConsoleAppender,
-    config::{Appender, Root},
-    encode::pattern::PatternEncoder,
-    Config,
-};
+use std::error::Error;
+use tracing_core::LevelFilter;
 
-pub fn init_log() -> Result<(), SetLoggerError> {
-    let stdout = ConsoleAppender::builder()
-        .encoder(Box::new(PatternEncoder::new("[{h({l})} - {f}:{L}] {m}{n}")))
-        .build();
-    let appender = Appender::builder().build("stdout", Box::new(stdout));
-
-    log4rs::init_config(
-        Config::builder()
-            .appender(appender)
-            .build(Root::builder().appender("stdout").build(LevelFilter::Debug))
-            .unwrap(),
-    )?;
-    update_panic_hook();
-
-    Ok(())
+pub fn init_log() -> Result<(), Box<dyn Error + Send + Sync>> {
+    let result = tracing_subscriber::fmt()
+        .with_max_level(LevelFilter::INFO)
+        .try_init();
+    if result.is_ok() {
+        update_panic_hook();
+    }
+    result
 }
 
 fn update_panic_hook() {

--- a/burn-train/Cargo.toml
+++ b/burn-train/Cargo.toml
@@ -16,7 +16,9 @@ burn-core = {path = "../burn-core", version = "0.9.0" }
 # Console
 indicatif = "0.17.5"
 log = {workspace = true}
-log4rs = {workspace = true}
+tracing-subscriber.workspace = true
+tracing-appender.workspace = true
+tracing-core.workspace = true
 
 # Metrics
 nvml-wrapper = "0.9.0"

--- a/burn-train/src/learner/builder.rs
+++ b/burn-train/src/learner/builder.rs
@@ -1,4 +1,4 @@
-use super::log::update_log_file;
+use super::log::install_file_logger;
 use super::Learner;
 use crate::checkpoint::{AsyncCheckpointer, Checkpointer, FileCheckpointer};
 use crate::logger::{FileMetricLogger, MetricLogger};
@@ -36,7 +36,6 @@ where
     metric_logger_valid: Option<Box<dyn MetricLogger + 'static>>,
     renderer: Option<Box<dyn DashboardRenderer + 'static>>,
     metrics: Metrics<T, V>,
-    log_to_file: bool,
 }
 
 impl<B, T, V, Model, Optim, LR> LearnerBuilder<B, T, V, Model, Optim, LR>
@@ -67,7 +66,6 @@ where
             metric_logger_valid: None,
             metrics: Metrics::new(),
             renderer: None,
-            log_to_file: true,
         }
     }
 
@@ -190,14 +188,6 @@ where
         self
     }
 
-    /// By default, Rust logs are captured and written into
-    /// `experiment.log`. If disabled, standard Rust log handling
-    /// will apply.
-    pub fn log_to_file(mut self, enabled: bool) -> Self {
-        self.log_to_file = enabled;
-        self
-    }
-
     /// Register a checkpointer that will save the [optimizer](Optimizer) and the
     /// [model](ADModule).
     ///
@@ -243,9 +233,7 @@ where
         Optim::Record: 'static,
         LR::Record: 'static,
     {
-        if self.log_to_file {
-            self.init_logger();
-        }
+        self.init_logger();
         let renderer = self
             .renderer
             .unwrap_or_else(|| Box::new(CLIDashboardRenderer::new()));
@@ -302,6 +290,6 @@ where
 
     fn init_logger(&self) {
         let file_path = format!("{}/experiment.log", self.directory);
-        update_log_file(file_path.as_str());
+        install_file_logger(file_path.as_str());
     }
 }

--- a/burn-train/src/learner/log.rs
+++ b/burn-train/src/learner/log.rs
@@ -1,76 +1,32 @@
-use log::LevelFilter;
-use log4rs::{
-    append::file::FileAppender,
-    config::{Appender, Config, Root},
-    encode::pattern::PatternEncoder,
-    Handle,
-};
-use std::{cell::Cell, sync::Mutex};
+use std::path::Path;
+use tracing_core::{Level, LevelFilter};
+use tracing_subscriber::filter::filter_fn;
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::{registry, Layer};
 
-static LOGGER_HANDLER: Mutex<Cell<Option<Handle>>> = Mutex::new(Cell::new(None));
-
-pub fn update_log_file(file_path: &str) {
-    let config = create_config(file_path);
-    set_config(config, file_path);
-}
-
-fn create_config(file_path: &str) -> Config {
-    let experiment = FileAppender::builder()
-        .encoder(Box::new(PatternEncoder::new(
-            "[{d(%+)(utc)} - {h({l})} - {f}:{L}] {m}{n}",
-        )))
-        .build(file_path)
-        .unwrap();
-
-    /// The wgpu crate is logging too much, so we skip `info` level.
-    #[derive(Debug)]
-    struct WgpuFilter;
-
-    impl log4rs::filter::Filter for WgpuFilter {
-        fn filter(&self, record: &log::Record) -> log4rs::filter::Response {
-            if !matches!(record.level(), log::Level::Info) {
-                return log4rs::filter::Response::Accept;
-            }
-
-            match record.module_path_static() {
-                Some(path) => {
-                    if path.starts_with("wgpu") {
-                        log4rs::filter::Response::Reject
-                    } else {
-                        log4rs::filter::Response::Accept
-                    }
+/// If a global tracing subscriber is not already configured, set up logging to a file,
+/// and add our custom panic hook.
+pub(crate) fn install_file_logger(file_path: &str) {
+    let path = Path::new(file_path);
+    let writer = tracing_appender::rolling::never(
+        path.parent().unwrap_or_else(|| Path::new(".")),
+        path.file_name().unwrap(),
+    );
+    let layer = tracing_subscriber::fmt::layer()
+        .with_writer(writer)
+        .with_filter(LevelFilter::INFO)
+        .with_filter(filter_fn(|m| {
+            if let Some(path) = m.module_path() {
+                // The wgpu crate is logging too much, so we skip `info` level.
+                if path.starts_with("wgpu") && *m.level() >= Level::INFO {
+                    return false;
                 }
-                None => log4rs::filter::Response::Accept,
             }
-        }
-    }
+            true
+        }));
 
-    Config::builder()
-        .appender(
-            Appender::builder()
-                .filter(Box::new(WgpuFilter))
-                .build("experiment", Box::new(experiment)),
-        )
-        .build(
-            Root::builder()
-                .appender("experiment")
-                .build(LevelFilter::Info),
-        )
-        .unwrap()
-}
-
-fn set_config(config: Config, file_path: &str) {
-    let mut cell = LOGGER_HANDLER.lock().unwrap();
-
-    match cell.get_mut() {
-        Some(handler) => {
-            handler.set_config(config);
-        }
-        None => {
-            let handler = log4rs::init_config(config).unwrap();
-            update_panic_hook(file_path);
-            cell.replace(Some(handler));
-        }
+    if registry().with(layer).try_init().is_ok() {
+        update_panic_hook(file_path);
     }
 }
 

--- a/burn-train/src/learner/log.rs
+++ b/burn-train/src/learner/log.rs
@@ -13,6 +13,7 @@ pub(crate) fn install_file_logger(file_path: &str) {
         path.file_name().unwrap(),
     );
     let layer = tracing_subscriber::fmt::layer()
+        .with_ansi(false)
         .with_writer(writer)
         .with_filter(LevelFilter::INFO)
         .with_filter(filter_fn(|m| {


### PR DESCRIPTION
update_log_file() is no longer public, as tracing expects things to only ever be initialized once. If the caller wants their own custom logging, they can set up their own tracing subscriber prior to training. This means we no longer need the log_to_file option in LearnerBuilder.

The logging output format is similar but not identical (eg module name is shown instead of file:line). This can be configured if the old format is preferable.

Closes #732

This removes a security warning:

error[vulnerability]: Potential segfault in the time crate
    │
487 │ time 0.1.45 registry+https://github.com/rust-lang/crates.io-index
    │ ----------------------------------------------------------------- security vulnerability detected

## Pull Request Template

### Checklist

- [x] Confirm that `run-checks` script has been executed.

### Related Issues/PRs

#732
