### PR TITLE
Add ui/metrics feature flags

### DIFF
--- a/burn-train/Cargo.toml
+++ b/burn-train/Cargo.toml
@@ -10,23 +10,33 @@ readme = "README.md"
 repository = "https://github.com/burn-rs/burn/tree/main/burn-train"
 version = "0.9.0"
 
+[features]
+cli = [
+    "indicatif",
+    "rgb",
+    "terminal_size",
+    "textplots",
+    "nvml-wrapper",
+    "sysinfo",
+    "systemstat"
+]
+
 [dependencies]
 burn-core = {path = "../burn-core", version = "0.9.0" }
 
-# Console
-indicatif = "0.17.5"
 log = {workspace = true}
 tracing-subscriber.workspace = true
 tracing-appender.workspace = true
 tracing-core.workspace = true
 
-# Metrics
-nvml-wrapper = "0.9.0"
-rgb = "0.8.36"
-terminal_size = "0.2.6"
-textplots = "0.8.0"
-sysinfo = "0.29.8"
-systemstat = "0.2.3"
+# CLI
+indicatif = { version = "0.17.5", optional = true }
+nvml-wrapper = { version = "0.9.0", optional = true }
+rgb = { version = "0.8.36", optional = true }
+terminal_size = { version = "0.2.6", optional = true }
+textplots = { version = "0.8.0", optional = true }
+sysinfo = { version = "0.29.8", optional = true }
+systemstat = { version = "0.2.3", optional = true }
 
 # Utilities
 derive-new = {workspace = true}

--- a/burn-train/Cargo.toml
+++ b/burn-train/Cargo.toml
@@ -11,14 +11,17 @@ repository = "https://github.com/burn-rs/burn/tree/main/burn-train"
 version = "0.9.0"
 
 [features]
+default = ["metrics", "ui"]
+metrics = [
+    "nvml-wrapper",
+    "sysinfo",
+    "systemstat"
+]
 ui = [
     "indicatif",
     "rgb",
     "terminal_size",
     "textplots",
-    "nvml-wrapper",
-    "sysinfo",
-    "systemstat"
 ]
 
 [dependencies]
@@ -29,14 +32,16 @@ tracing-subscriber.workspace = true
 tracing-appender.workspace = true
 tracing-core.workspace = true
 
-# CLI
-indicatif = { version = "0.17.5", optional = true }
+# Metrics
 nvml-wrapper = { version = "0.9.0", optional = true }
+sysinfo = { version = "0.29.8", optional = true }
+systemstat = { version = "0.2.3", optional = true }
+
+# Text UI
+indicatif = { version = "0.17.5", optional = true }
 rgb = { version = "0.8.36", optional = true }
 terminal_size = { version = "0.2.6", optional = true }
 textplots = { version = "0.8.0", optional = true }
-sysinfo = { version = "0.29.8", optional = true }
-systemstat = { version = "0.2.3", optional = true }
 
 # Utilities
 derive-new = {workspace = true}

--- a/burn-train/Cargo.toml
+++ b/burn-train/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/burn-rs/burn/tree/main/burn-train"
 version = "0.9.0"
 
 [features]
-cli = [
+ui = [
     "indicatif",
     "rgb",
     "terminal_size",

--- a/burn-train/src/learner/builder.rs
+++ b/burn-train/src/learner/builder.rs
@@ -142,7 +142,6 @@ where
     /// Only [numeric](crate::metric::Numeric) metric can be displayed on a plot.
     /// If the same metric is also registered for the [validation split](Self::metric_valid_plot),
     /// the same graph will be used for both.
-    #[cfg(feature = "ui")]
     pub fn metric_train_plot<M>(mut self, metric: M) -> Self
     where
         M: Metric + crate::metric::Numeric + 'static,
@@ -161,7 +160,6 @@ where
     /// Only [numeric](crate::metric::Numeric) metric can be displayed on a plot.
     /// If the same metric is also registered for the [training split](Self::metric_train_plot),
     /// the same graph will be used for both.
-    #[cfg(feature = "ui")]
     pub fn metric_valid_plot<M: Metric + crate::metric::Numeric + 'static>(
         mut self,
         metric: M,

--- a/burn-train/src/learner/builder.rs
+++ b/burn-train/src/learner/builder.rs
@@ -142,7 +142,7 @@ where
     /// Only [numeric](crate::metric::Numeric) metric can be displayed on a plot.
     /// If the same metric is also registered for the [validation split](Self::metric_valid_plot),
     /// the same graph will be used for both.
-    #[cfg(feature = "cli")]
+    #[cfg(feature = "ui")]
     pub fn metric_train_plot<M>(mut self, metric: M) -> Self
     where
         M: Metric + crate::metric::Numeric + 'static,
@@ -161,7 +161,7 @@ where
     /// Only [numeric](crate::metric::Numeric) metric can be displayed on a plot.
     /// If the same metric is also registered for the [training split](Self::metric_train_plot),
     /// the same graph will be used for both.
-    #[cfg(feature = "cli")]
+    #[cfg(feature = "ui")]
     pub fn metric_valid_plot<M: Metric + crate::metric::Numeric + 'static>(
         mut self,
         metric: M,

--- a/burn-train/src/learner/builder.rs
+++ b/burn-train/src/learner/builder.rs
@@ -2,9 +2,9 @@ use super::log::install_file_logger;
 use super::Learner;
 use crate::checkpoint::{AsyncCheckpointer, Checkpointer, FileCheckpointer};
 use crate::logger::{FileMetricLogger, MetricLogger};
-use crate::metric::dashboard::cli::CLIDashboardRenderer;
+use crate::metric::dashboard::CLIDashboardRenderer;
 use crate::metric::dashboard::{Dashboard, DashboardRenderer, MetricWrapper, Metrics};
-use crate::metric::{Adaptor, Metric, Numeric};
+use crate::metric::{Adaptor, Metric};
 use crate::AsyncTrainerCallback;
 use burn_core::lr_scheduler::LRScheduler;
 use burn_core::module::ADModule;
@@ -139,12 +139,13 @@ where
     ///
     /// # Notes
     ///
-    /// Only [numeric](Numeric) metric can be displayed on a plot.
+    /// Only [numeric](crate::metric::Numeric) metric can be displayed on a plot.
     /// If the same metric is also registered for the [validation split](Self::metric_valid_plot),
     /// the same graph will be used for both.
+    #[cfg(feature = "cli")]
     pub fn metric_train_plot<M>(mut self, metric: M) -> Self
     where
-        M: Metric + Numeric + 'static,
+        M: Metric + crate::metric::Numeric + 'static,
         T: Adaptor<M::Input>,
     {
         self.metrics
@@ -157,10 +158,14 @@ where
     ///
     /// # Notes
     ///
-    /// Only [numeric](Numeric) metric can be displayed on a plot.
+    /// Only [numeric](crate::metric::Numeric) metric can be displayed on a plot.
     /// If the same metric is also registered for the [training split](Self::metric_train_plot),
     /// the same graph will be used for both.
-    pub fn metric_valid_plot<M: Metric + Numeric + 'static>(mut self, metric: M) -> Self
+    #[cfg(feature = "cli")]
+    pub fn metric_valid_plot<M: Metric + crate::metric::Numeric + 'static>(
+        mut self,
+        metric: M,
+    ) -> Self
     where
         V: Adaptor<M::Input>,
     {

--- a/burn-train/src/metric/dashboard/cli_stub.rs
+++ b/burn-train/src/metric/dashboard/cli_stub.rs
@@ -1,0 +1,25 @@
+use crate::metric::dashboard::{DashboardMetricState, DashboardRenderer, TrainingProgress};
+
+/// A simple renderer for when the cli feature is not enabled.
+pub struct CLIDashboardRenderer;
+
+impl CLIDashboardRenderer {
+    /// Create a new instance.
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl DashboardRenderer for CLIDashboardRenderer {
+    fn update_train(&mut self, _state: DashboardMetricState) {}
+
+    fn update_valid(&mut self, _state: DashboardMetricState) {}
+
+    fn render_train(&mut self, item: TrainingProgress) {
+        dbg!(item);
+    }
+
+    fn render_valid(&mut self, item: TrainingProgress) {
+        dbg!(item);
+    }
+}

--- a/burn-train/src/metric/dashboard/mod.rs
+++ b/burn-train/src/metric/dashboard/mod.rs
@@ -1,7 +1,7 @@
 /// Command line interface module for the dashboard.
-#[cfg(feature = "cli")]
+#[cfg(feature = "ui")]
 mod cli;
-#[cfg(not(feature = "cli"))]
+#[cfg(not(feature = "ui"))]
 mod cli_stub;
 
 mod base;
@@ -10,7 +10,7 @@ mod plot;
 pub use base::*;
 pub use plot::*;
 
-#[cfg(feature = "cli")]
+#[cfg(feature = "ui")]
 pub use cli::CLIDashboardRenderer;
-#[cfg(not(feature = "cli"))]
+#[cfg(not(feature = "ui"))]
 pub use cli_stub::CLIDashboardRenderer;

--- a/burn-train/src/metric/dashboard/mod.rs
+++ b/burn-train/src/metric/dashboard/mod.rs
@@ -1,8 +1,16 @@
 /// Command line interface module for the dashboard.
-pub mod cli;
+#[cfg(feature = "cli")]
+mod cli;
+#[cfg(not(feature = "cli"))]
+mod cli_stub;
 
 mod base;
 mod plot;
 
 pub use base::*;
 pub use plot::*;
+
+#[cfg(feature = "cli")]
+pub use cli::CLIDashboardRenderer;
+#[cfg(not(feature = "cli"))]
+pub use cli_stub::CLIDashboardRenderer;

--- a/burn-train/src/metric/dashboard/plot.rs
+++ b/burn-train/src/metric/dashboard/plot.rs
@@ -155,6 +155,6 @@ impl TextPlot {
     /// The rendered text plot.
     #[cfg(not(feature = "ui"))]
     pub fn render(&self) -> String {
-        panic!("metrics feature not enabled on burn-train")
+        panic!("ui feature not enabled on burn-train")
     }
 }

--- a/burn-train/src/metric/dashboard/plot.rs
+++ b/burn-train/src/metric/dashboard/plot.rs
@@ -104,7 +104,7 @@ impl TextPlot {
     /// # Returns
     ///
     /// The rendered text plot.
-    #[cfg(feature = "cli")]
+    #[cfg(feature = "ui")]
     pub fn render(&self) -> String {
         use rgb::RGB8;
         use terminal_size::{terminal_size, Height, Width};
@@ -153,7 +153,7 @@ impl TextPlot {
     /// # Returns
     ///
     /// The rendered text plot.
-    #[cfg(not(feature = "cli"))]
+    #[cfg(not(feature = "ui"))]
     pub fn render(&self) -> String {
         panic!("metrics feature not enabled on burn-train")
     }

--- a/burn-train/src/metric/dashboard/plot.rs
+++ b/burn-train/src/metric/dashboard/plot.rs
@@ -1,7 +1,3 @@
-use rgb::RGB8;
-use terminal_size::{terminal_size, Height, Width};
-use textplots::{Chart, ColorPlot, Shape};
-
 /// Text plot.
 pub struct TextPlot {
     train: Vec<(f32, f32)>,
@@ -108,7 +104,12 @@ impl TextPlot {
     /// # Returns
     ///
     /// The rendered text plot.
+    #[cfg(feature = "cli")]
     pub fn render(&self) -> String {
+        use rgb::RGB8;
+        use terminal_size::{terminal_size, Height, Width};
+        use textplots::{Chart, ColorPlot, Shape};
+
         let train_color = RGB8::new(255, 140, 140);
         let valid_color = RGB8::new(140, 140, 255);
 
@@ -145,5 +146,15 @@ impl TextPlot {
             .linecolorplot(&Shape::Lines(&self.train), train_color)
             .linecolorplot(&Shape::Lines(&self.valid), valid_color)
             .to_string()
+    }
+
+    /// Renders the text plot.
+    ///
+    /// # Returns
+    ///
+    /// The rendered text plot.
+    #[cfg(not(feature = "cli"))]
+    pub fn render(&self) -> String {
+        panic!("metrics feature not enabled on burn-train")
     }
 }

--- a/burn-train/src/metric/mod.rs
+++ b/burn-train/src/metric/mod.rs
@@ -6,30 +6,30 @@ pub mod state;
 
 mod acc;
 mod base;
-#[cfg(feature = "ui")]
+#[cfg(feature = "metrics")]
 mod cpu_temp;
-#[cfg(feature = "ui")]
+#[cfg(feature = "metrics")]
 mod cpu_use;
-#[cfg(feature = "ui")]
+#[cfg(feature = "metrics")]
 mod cuda;
-#[cfg(feature = "ui")]
+#[cfg(feature = "metrics")]
 mod gpu_temp;
 mod learning_rate;
 mod loss;
-#[cfg(feature = "ui")]
+#[cfg(feature = "metrics")]
 mod memory_use;
 
 pub use acc::*;
 pub use base::*;
-#[cfg(feature = "ui")]
+#[cfg(feature = "metrics")]
 pub use cpu_temp::*;
-#[cfg(feature = "ui")]
+#[cfg(feature = "metrics")]
 pub use cpu_use::*;
-#[cfg(feature = "ui")]
+#[cfg(feature = "metrics")]
 pub use cuda::*;
-#[cfg(feature = "ui")]
+#[cfg(feature = "metrics")]
 pub use gpu_temp::*;
 pub use learning_rate::*;
 pub use loss::*;
-#[cfg(feature = "ui")]
+#[cfg(feature = "metrics")]
 pub use memory_use::*;

--- a/burn-train/src/metric/mod.rs
+++ b/burn-train/src/metric/mod.rs
@@ -6,30 +6,30 @@ pub mod state;
 
 mod acc;
 mod base;
-#[cfg(feature = "cli")]
+#[cfg(feature = "ui")]
 mod cpu_temp;
-#[cfg(feature = "cli")]
+#[cfg(feature = "ui")]
 mod cpu_use;
-#[cfg(feature = "cli")]
+#[cfg(feature = "ui")]
 mod cuda;
-#[cfg(feature = "cli")]
+#[cfg(feature = "ui")]
 mod gpu_temp;
 mod learning_rate;
 mod loss;
-#[cfg(feature = "cli")]
+#[cfg(feature = "ui")]
 mod memory_use;
 
 pub use acc::*;
 pub use base::*;
-#[cfg(feature = "cli")]
+#[cfg(feature = "ui")]
 pub use cpu_temp::*;
-#[cfg(feature = "cli")]
+#[cfg(feature = "ui")]
 pub use cpu_use::*;
-#[cfg(feature = "cli")]
+#[cfg(feature = "ui")]
 pub use cuda::*;
-#[cfg(feature = "cli")]
+#[cfg(feature = "ui")]
 pub use gpu_temp::*;
 pub use learning_rate::*;
 pub use loss::*;
-#[cfg(feature = "cli")]
+#[cfg(feature = "ui")]
 pub use memory_use::*;

--- a/burn-train/src/metric/mod.rs
+++ b/burn-train/src/metric/mod.rs
@@ -6,20 +6,30 @@ pub mod state;
 
 mod acc;
 mod base;
+#[cfg(feature = "cli")]
 mod cpu_temp;
+#[cfg(feature = "cli")]
 mod cpu_use;
+#[cfg(feature = "cli")]
 mod cuda;
+#[cfg(feature = "cli")]
 mod gpu_temp;
 mod learning_rate;
 mod loss;
+#[cfg(feature = "cli")]
 mod memory_use;
 
 pub use acc::*;
 pub use base::*;
+#[cfg(feature = "cli")]
 pub use cpu_temp::*;
+#[cfg(feature = "cli")]
 pub use cpu_use::*;
+#[cfg(feature = "cli")]
 pub use cuda::*;
+#[cfg(feature = "cli")]
 pub use gpu_temp::*;
 pub use learning_rate::*;
 pub use loss::*;
+#[cfg(feature = "cli")]
 pub use memory_use::*;

--- a/burn/Cargo.toml
+++ b/burn/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/burn-rs/burn"
 version = "0.9.0"
 
 [features]
-default = ["std", "train-cli"]
+default = ["std", "train-ui"]
 experimental-named-tensor = ["burn-core/experimental-named-tensor"]
 std = [
   "burn-core/std",
@@ -20,7 +20,7 @@ std = [
 # Training requires std
 train = ["std", "burn-train"]
 # Includes the Text UI (progress bars, metric plots)
-train-cli = ["train", "burn-train/cli"]
+train-ui = ["train", "burn-train/ui"]
 
 dataset = ["burn-core/dataset"]
 dataset-sqlite = ["burn-core/dataset-sqlite"]

--- a/burn/Cargo.toml
+++ b/burn/Cargo.toml
@@ -16,7 +16,9 @@ experimental-named-tensor = ["burn-core/experimental-named-tensor"]
 std = [
   "burn-core/std",
 ]
-train = ["std", "burn-train"] # Training requires std
+# Training requires std
+train = ["std", "burn-train"]
+train-cli = ["train", "burn-train/cli"]
 
 dataset = ["burn-core/dataset"]
 dataset-sqlite = ["burn-core/dataset-sqlite"]

--- a/burn/Cargo.toml
+++ b/burn/Cargo.toml
@@ -11,13 +11,15 @@ repository = "https://github.com/burn-rs/burn"
 version = "0.9.0"
 
 [features]
-default = ["std", "train"]
+default = ["std", "train-cli"]
 experimental-named-tensor = ["burn-core/experimental-named-tensor"]
 std = [
   "burn-core/std",
 ]
+
 # Training requires std
 train = ["std", "burn-train"]
+# Includes the Text UI (progress bars, metric plots)
 train-cli = ["train", "burn-train/cli"]
 
 dataset = ["burn-core/dataset"]

--- a/burn/Cargo.toml
+++ b/burn/Cargo.toml
@@ -11,7 +11,11 @@ repository = "https://github.com/burn-rs/burn"
 version = "0.9.0"
 
 [features]
-default = ["std", "train-ui"]
+default = [
+  "std",
+  "train-ui",
+  "train-metrics"
+]
 experimental-named-tensor = ["burn-core/experimental-named-tensor"]
 std = [
   "burn-core/std",
@@ -21,6 +25,8 @@ std = [
 train = ["std", "burn-train"]
 # Includes the Text UI (progress bars, metric plots)
 train-ui = ["train", "burn-train/ui"]
+# Includes system info metrics (CPU/GPU usage, etc)
+train-metrics = ["train", "burn-train/metrics"]
 
 dataset = ["burn-core/dataset"]
 dataset-sqlite = ["burn-core/dataset-sqlite"]
@@ -31,4 +37,4 @@ dataset-sqlite-bundled = ["burn-core/dataset-sqlite-bundled"]
 # ** Please make sure all dependencies support no_std when std is disabled **
 
 burn-core = {path = "../burn-core", version = "0.9.0", default-features = false}
-burn-train = {path = "../burn-train", version = "0.9.0", optional = true}
+burn-train = {path = "../burn-train", version = "0.9.0", optional = true, default-features = false }


### PR DESCRIPTION
Partially implements #729:

- ~The burn crate no longer enables the training module unless the train feature is enabled.~
- Added new flags so the UI and/or system metrics can be excluded.

textplots has two security warnings that can be avoided when the CLI
is excluded:

33 │ atty 0.2.14 registry+https://github.com/rust-lang/crates.io-index
   │ ----------------------------------------------------------------- unsound advisory detected
   │
   = ID: RUSTSEC-2021-0145
   = Advisory: https://rustsec.org/advisories/RUSTSEC-2021-0145
   = On windows, `atty` dereferences a potentially unaligned pointer.

16 │ ansi_term 0.12.1 registry+https://github.com/rust-lang/crates.io-index
   │ ---------------------------------------------------------------------- unmaintained advisory detected
   │
   = ID: RUSTSEC-2021-0139
   = Advisory: https://rustsec.org/advisories/RUSTSEC-2021-0139
   = The maintainer has advised that this crate is deprecated and will not receive any maintenance.


## Pull Request Template

### Checklist

- [x] Confirm that `run-checks` script has been executed.

### Related Issues/PRs

#729
