### PR TITLE
Add ability to interrupt training loop

### DIFF
--- a/burn-train/src/learner/builder.rs
+++ b/burn-train/src/learner/builder.rs
@@ -12,6 +12,7 @@ use burn_core::optim::Optimizer;
 use burn_core::record::FileRecorder;
 use burn_core::tensor::backend::ADBackend;
 
+use crate::learner::base::TrainingInterrupter;
 use std::sync::Arc;
 
 /// Struct to configure and create a [learner](Learner).
@@ -36,6 +37,7 @@ where
     metric_logger_valid: Option<Box<dyn MetricLogger + 'static>>,
     renderer: Option<Box<dyn DashboardRenderer + 'static>>,
     metrics: Metrics<T, V>,
+    interrupter: Option<TrainingInterrupter>,
 }
 
 impl<B, T, V, Model, Optim, LR> LearnerBuilder<B, T, V, Model, Optim, LR>
@@ -66,6 +68,7 @@ where
             metric_logger_valid: None,
             metrics: Metrics::new(),
             renderer: None,
+            interrupter: None,
         }
     }
 
@@ -188,6 +191,12 @@ where
         self
     }
 
+    /// Provide a handle that can be used to interrupt training.
+    pub fn interrupter(mut self, interrupter: TrainingInterrupter) -> Self {
+        self.interrupter = Some(interrupter);
+        self
+    }
+
     /// Register a checkpointer that will save the [optimizer](Optimizer) and the
     /// [model](ADModule).
     ///
@@ -285,6 +294,7 @@ where
             checkpointer_scheduler,
             grad_accumulation: self.grad_accumulation,
             devices: self.devices,
+            interrupter: self.interrupter.unwrap_or_default(),
         }
     }
 

--- a/burn-train/src/learner/builder.rs
+++ b/burn-train/src/learner/builder.rs
@@ -37,7 +37,7 @@ where
     metric_logger_valid: Option<Box<dyn MetricLogger + 'static>>,
     renderer: Option<Box<dyn DashboardRenderer + 'static>>,
     metrics: Metrics<T, V>,
-    interrupter: Option<TrainingInterrupter>,
+    interrupter: TrainingInterrupter,
 }
 
 impl<B, T, V, Model, Optim, LR> LearnerBuilder<B, T, V, Model, Optim, LR>
@@ -68,7 +68,7 @@ where
             metric_logger_valid: None,
             metrics: Metrics::new(),
             renderer: None,
-            interrupter: None,
+            interrupter: TrainingInterrupter::new(),
         }
     }
 
@@ -191,10 +191,9 @@ where
         self
     }
 
-    /// Provide a handle that can be used to interrupt training.
-    pub fn interrupter(mut self, interrupter: TrainingInterrupter) -> Self {
-        self.interrupter = Some(interrupter);
-        self
+    /// Provides a handle that can be used to interrupt training.
+    pub fn interrupter(&self) -> TrainingInterrupter {
+        self.interrupter.clone()
     }
 
     /// Register a checkpointer that will save the [optimizer](Optimizer) and the
@@ -294,7 +293,7 @@ where
             checkpointer_scheduler,
             grad_accumulation: self.grad_accumulation,
             devices: self.devices,
-            interrupter: self.interrupter.unwrap_or_default(),
+            interrupter: self.interrupter,
         }
     }
 

--- a/burn-train/src/learner/train_val.rs
+++ b/burn-train/src/learner/train_val.rs
@@ -156,14 +156,20 @@ where
                     &mut self.lr_scheduler,
                     &mut self.callback,
                     self.devices.clone(),
+                    &self.interrupter,
                 )
             } else {
-                (model, optim) =
-                    epoch_train.run(model, optim, &mut self.lr_scheduler, &mut self.callback);
+                (model, optim) = epoch_train.run(
+                    model,
+                    optim,
+                    &mut self.lr_scheduler,
+                    &mut self.callback,
+                    &self.interrupter,
+                );
             }
 
             let epoch_valid = ValidEpoch::new(dataloader_valid.clone(), epoch, self.num_epochs);
-            epoch_valid.run(&model, &mut self.callback);
+            epoch_valid.run(&model, &mut self.callback, &self.interrupter);
 
             Self::checkpoint(
                 &model,


### PR DESCRIPTION
Closes #714

## Pull Request Template

### Checklist

- [x] Confirm that `run-checks` script has been executed.

### Changes

@nathanielsimard I have a mild preference for the API in the first commit, as builders typically have data passed into them instead of out from them. If we wanted to share the underlying AtomicBool with other items, couldn't we also accomplish that in the future by adding a pub(crate) fn to the interrupter that returns its inner value? But not a big deal; either way works for me.

### Testing

Manual testing to confirm .stop() interrupts training.