### PR TITLE
Add `cargo-xtask` helper and move scripts into it

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --manifest-path ./xtask/Cargo.toml --"

--- a/.github/workflows/publish-template.yml
+++ b/.github/workflows/publish-template.yml
@@ -18,10 +18,7 @@ jobs:
       - name: install rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: compile publish binary
-        run: rustc scripts/publish.rs --crate-type bin --out-dir scripts
-
       - name: publish to crates.io
-        run: ./scripts/publish ${{ inputs.crate }}
+        run: cargo xtask publish ${{ inputs.crate }}
         env:
           CRATES_IO_API_TOKEN: ${{ secrets.CRATES_IO_API_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         rust: [stable, 1.71.0]
-        test: [std, no_std]
+        test: ['std', 'no-std']
     steps:
       - name: free disk space
         run: |
@@ -50,7 +50,7 @@ jobs:
           sudo apt install -y libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
 
       - name: run checks & tests
-        run: RUST_MATRIX=${{ matrix.rust }} ./run-checks.sh ${{ matrix.test }}
+        run: RUST_MATRIX=${{ matrix.rust }} cargo xtask run-checks ${{ matrix.test }}
 
   check-typos:
     runs-on: ubuntu-latest
@@ -59,4 +59,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: run spelling checks using typos
-        run: ./run-checks.sh typos
+        run: cargo xtask run-checks typos

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
   "burn-tensor-testgen",
   "burn-tensor",
   "burn-train",
+  "xtask",
   "examples/*",
 ]
 

--- a/run-checks.ps1
+++ b/run-checks.ps1
@@ -16,10 +16,7 @@
 # Exit if any command fails
 $ErrorActionPreference = "Stop"
 
-# Compile run-checks binary
-rustc scripts/run-checks.rs --crate-type bin --out-dir scripts
-
 # Run binary passing the first input parameter, who is mandatory.
 # If the input parameter is missing or wrong, it will be the `run-checks`
 # binary which will be responsible of arising an error.
-./scripts/run-checks $args[0]
+cargo xtask run-checks $args[0]

--- a/run-checks.sh
+++ b/run-checks.sh
@@ -19,10 +19,7 @@ set -e
 #
 # If no `environment` value has been passed, run all checks except examples.
 
-# Compile run-checks binary
-rustc scripts/run-checks.rs --crate-type bin --out-dir scripts
-
 # Run binary passing the first input parameter, who is mandatory.
 # If the input parameter is missing or wrong, it will be the `run-checks`
 # binary which will be responsible of arising an error.
-./scripts/run-checks $1
+cargo xtask run-checks $1

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.75"
+clap = { version = "4.4.2", features = ["derive"] }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,34 @@
+use clap::{Parser, Subcommand};
+
+mod publish;
+mod runchecks;
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Publish a crate to crates.io
+    Publish {
+        /// The name of the crate to publish on crates.io
+        name: String,
+    },
+    /// Run the specified `burn` tests and checks locally.
+    RunChecks {
+        /// The environment to run checks against
+        env: runchecks::CheckType,
+    },
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+
+    match args.command {
+        Command::RunChecks { env } => runchecks::run(env),
+        Command::Publish { name } => publish::run(name),
+    }
+}

--- a/xtask/src/publish.rs
+++ b/xtask/src/publish.rs
@@ -97,12 +97,7 @@ fn publish(crate_name: String) {
     cargo_publish(&["-p", &crate_name, "--token", &crates_io_token]);
 }
 
-fn main() {
-    // Get crate name
-    let crate_name = env::args()
-        .nth(1) // Index of the first argument, because 0 is the binary name
-        .expect("You need to pass the crate name as first argument!");
-
+pub fn run(crate_name: String) -> anyhow::Result<()> {
     println!("Publishing {crate_name}...\n");
 
     // Retrieve local version for crate
@@ -132,4 +127,6 @@ fn main() {
         // Publish crate
         publish(crate_name);
     }
+
+    Ok(())
 }

--- a/xtask/src/runchecks.rs
+++ b/xtask/src/runchecks.rs
@@ -302,8 +302,22 @@ fn check_examples() {
     });
 }
 
+#[derive(clap::ValueEnum, Default, Copy, Clone, PartialEq, Eq)]
+pub enum CheckType {
+    /// Run all checks.
+    #[default]
+    All,
+    /// Run `std` environment checks
+    Std,
+    /// Run `no-std` environment checks
+    NoStd,
+    /// Check for typos
+    Typos,
+    /// Test the examples
+    Examples,
+}
 
-fn main() {
+pub fn run(env: CheckType) -> anyhow::Result<()> {
     // Start time measurement
     let start = Instant::now();
 
@@ -313,18 +327,12 @@ fn main() {
     // are run.
     //
     // If no environment has been passed, run all checks.
-    match env::args()
-        .nth(
-            1, /* Index of the first argument, because 0 is the binary name */
-        )
-        .as_deref()
-    {
-        Some("std") => std_checks(),
-        Some("no_std") => no_std_checks(),
-        Some("typos") => check_typos(),
-        Some("examples") => check_examples(),
-        Some(other) => panic!("Unexpected test type: {}", other),
-        None => {
+    match env {
+        CheckType::Std => std_checks(),
+        CheckType::NoStd => no_std_checks(),
+        CheckType::Typos => check_typos(),
+        CheckType::Examples => check_examples(),
+        CheckType::All => {
             /* Run all checks */
             check_typos();
             std_checks();
@@ -339,4 +347,6 @@ fn main() {
 
     // Print duration
     println!("Time elapsed for the current execution: {:?}", duration);
+
+    Ok(())
 }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [X] Confirm that `run-checks` script has been executed.

### Related Issues/PRs

#756

### Changes

Move all helper scripts into a new `cargo-xtask` binary, following the [`cargo-xtask`](https://github.com/matklad/cargo-xtask) pattern.

The new way to run these helper scripts is via (e.g.):
```
> cargo xtask run-checks
```