### PR TITLE
Doc: improve config builder docs

### DIFF
--- a/burn-derive/src/config/analyzer_struct.rs
+++ b/burn-derive/src/config/analyzer_struct.rs
@@ -205,11 +205,16 @@ impl ConfigAnalyzer for ConfigStructAnalyzer {
 
         for (field, _) in self.fields_default.iter() {
             let name = field.ident();
+            let doc = field.doc().unwrap_or_else(|| {
+                quote! {
+                        /// Set the default value for the field.
+                }
+            });
             let ty = &field.field.ty;
             let fn_name = Ident::new(&format!("with_{name}"), name.span());
 
             body.extend(quote! {
-                /// Set the default value for the field.
+                #doc
                 pub fn #fn_name(mut self, #name: #ty) -> Self {
                     self.#name = #name;
                     self

--- a/burn-derive/src/shared/field.rs
+++ b/burn-derive/src/shared/field.rs
@@ -1,5 +1,6 @@
 use super::attribute::AttributeAnalyzer;
 use proc_macro2::Ident;
+use quote::quote;
 use syn::{Field, Type, TypePath};
 
 #[derive(Clone)]
@@ -64,6 +65,19 @@ impl FieldTypeAnalyzer {
             }
         }
         name
+    }
+
+    /// Returns the doc of the field if present.
+    pub fn doc(&self) -> Option<proc_macro2::TokenStream> {
+        self.field
+            .attrs
+            .iter()
+            .find(|attr| attr.path().is_ident("doc"))
+            .map(|doc| {
+                quote! {
+                    #doc
+                }
+            })
     }
 
     pub fn attributes(&self) -> impl Iterator<Item = AttributeAnalyzer> {


### PR DESCRIPTION
Small enhancement where the docs from config fields are copied to their corresponding builder methods for better DX.

![image](https://github.com/burn-rs/burn/assets/14095719/4bb773af-893e-4422-bf7b-31db02b725d1)
