### PR TITLE
Remove binaries from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,3 @@ Cargo.lock
 
 .idea
 .vscode
-
-# Ignore binaries contained in the `scripts` directory
-scripts/publish
-scripts/run-checks


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirm that `run-checks` script has been executed.

### Changes

Since #757, the `script` directory does not exist anymore, so we can remove its entry from `.gitignore`