### PR TITLE
Avoid building `xtask` when invoking `cargo build`

### DIFF
--- a/xtask/src/runchecks.rs
+++ b/xtask/src/runchecks.rs
@@ -234,7 +234,7 @@ fn std_checks() {
     println!("Running std checks");
 
     // Build each workspace
-    cargo_build(&["--workspace"]);
+    cargo_build(&["--workspace", "--exclude=xtask"]);
 
     // Test each workspace
     cargo_test(&["--workspace"]);


### PR DESCRIPTION
Follow-up to #757

We can't run `cargo build` as-is anymore since it would attempt to rebuild the crate that is invoking the command.