### PR TITLE
Fix missing train re-export when using train-minimal

### DIFF
--- a/burn/src/lib.rs
+++ b/burn/src/lib.rs
@@ -10,7 +10,7 @@
 pub use burn_core::*;
 
 /// Train module
-#[cfg(feature = "train")]
+#[cfg(any(feature = "train", feature = "train-minimal"))]
 pub mod train {
     pub use burn_train::*;
 }


### PR DESCRIPTION
Accidental regression in #773

## Pull Request Template

### Checklist

Tests are currently broken for me - if I check out the commit for #773 and run 'cargo check', I get a compile failure. The previous commit before it works fine, and I've tried removing Cargo.lock. I looked through the changes in #773 but couldn't obviously see the problem - any ideas?

```
dae@dtop:~/burn% cargo check
    Blocking waiting for file lock on build directory
   Compiling torch-sys v0.13.0
    Checking burn-ndarray v0.9.0 (/home/dae/burn/burn-ndarray)
    Checking burn-wgpu v0.9.0 (/home/dae/burn/burn-wgpu)
    Checking burn-dataset v0.9.0 (/home/dae/burn/burn-dataset)
   Compiling burn-tensor v0.9.0 (/home/dae/burn/burn-tensor)
    Checking openssl-sys v0.9.93
    Checking candle-core v0.2.1 (https://github.com/huggingface/candle?rev=237323c#237323c2)
The following warnings were emitted during compilation:

warning: libtch/torch_api.cpp:1:9: fatal error: torch/csrc/autograd/engine.h: No such file or directory
warning:     1 | #include<torch/csrc/autograd/engine.h>
warning:       |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
warning: compilation terminated.
warning: In file included from libtch/torch_api_generated.h:2,
warning:                  from libtch/torch_api_generated.cpp:2:
warning: libtch/torch_api.h:6:9: fatal error: torch/torch.h: No such file or directory
warning:     6 | #include<torch/torch.h>
warning:       |         ^~~~~~~~~~~~~~~
warning: compilation terminated.
warning: ToolExecError: Command "c++" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-4" "-fno-omit-frame-pointer" "-m64" "-I" "/home/dae/Local/rust/debug/build/torch-sys-9a97c6e7b93f2160/out/libtorch/libtorch/include" "-I" "/home/dae/Local/rust/debug/build/torch-sys-9a97c6e7b93f2160/out/libtorch/libtorch/include/torch/csrc/api/include" "-Wl,-rpath=/home/dae/Local/rust/debug/build/torch-sys-9a97c6e7b93f2160/out/libtorch/libtorch/lib" "-std=c++14" "-D_GLIBCXX_USE_CXX11_ABI=1" "-o" "/home/dae/Local/rust/debug/build/torch-sys-9a97c6e7b93f2160/out/libtch/torch_api.o" "-c" "libtch/torch_api.cpp" with args "c++" did not execute successfully (status code exit status: 1).
warning: ToolExecError: Command "c++" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-4" "-fno-omit-frame-pointer" "-m64" "-I" "/home/dae/Local/rust/debug/build/torch-sys-9a97c6e7b93f2160/out/libtorch/libtorch/include" "-I" "/home/dae/Local/rust/debug/build/torch-sys-9a97c6e7b93f2160/out/libtorch/libtorch/include/torch/csrc/api/include" "-Wl,-rpath=/home/dae/Local/rust/debug/build/torch-sys-9a97c6e7b93f2160/out/libtorch/libtorch/lib" "-std=c++14" "-D_GLIBCXX_USE_CXX11_ABI=1" "-o" "/home/dae/Local/rust/debug/build/torch-sys-9a97c6e7b93f2160/out/libtch/torch_api_generated.o" "-c" "libtch/torch_api_generated.cpp" with args "c++" did not execute successfully (status code exit status: 1).

error: failed to run custom build command for `torch-sys v0.13.0
```

The download-libtorch feature does appear to be enabled, and I don't see a different compared to the previous commit:

```
cargo tree -e features | rg torch
│   │       │       ├── torch-sys feature "default"
│   │       │       │   └── torch-sys v0.13.0
│   │       └── tch feature "download-libtorch"
│   │           └── torch-sys feature "download-libtorch"
│   │               ├── torch-sys v0.13.0 (*)
│   │               ├── torch-sys feature "serde"
│   │               │   └── torch-sys v0.13.0 (*)
│   │               ├── torch-sys feature "serde_json"
│   │               │   └── torch-sys v0.13.0 (*)
│   │               └── torch-sys feature "ureq"
│   │                   └── torch-sys v0.13.0 (*)
```
