### PR TITLE
Add support for different record types in ONNX

### DIFF
--- a/burn-core/src/record/file.rs
+++ b/burn-core/src/record/file.rs
@@ -294,13 +294,20 @@ impl<S: PrecisionSettings> Recorder for NamedMpkFileRecorder<S> {
 #[cfg(test)]
 mod tests {
 
+    use burn_tensor::backend::Backend;
+
     use super::*;
     use crate::{
         module::Module,
-        nn,
+        nn::{
+            conv::{Conv2d, Conv2dConfig},
+            Linear, LinearConfig,
+        },
         record::{BinBytesRecorder, FullPrecisionSettings},
         TestBackend,
     };
+
+    use crate as burn;
 
     static FILE_PATH: &str = "/tmp/burn_test_file_recorder";
 
@@ -351,7 +358,22 @@ mod tests {
         assert_eq!(model_bytes_after, model_bytes_before);
     }
 
-    pub fn create_model() -> nn::Linear<TestBackend> {
-        nn::LinearConfig::new(32, 32).with_bias(true).init()
+    #[derive(Module, Debug)]
+    pub struct Model<B: Backend> {
+        conv2d1: Conv2d<B>,
+        linear1: Linear<B>,
+        phantom: core::marker::PhantomData<B>,
+    }
+
+    pub fn create_model() -> Model<TestBackend> {
+        let conv2d1 = Conv2dConfig::new([1, 8], [3, 3]).init();
+
+        let linear1 = LinearConfig::new(32, 32).with_bias(true).init();
+
+        Model {
+            conv2d1,
+            linear1,
+            phantom: core::marker::PhantomData,
+        }
     }
 }

--- a/burn-core/src/record/recorder.rs
+++ b/burn-core/src/record/recorder.rs
@@ -179,7 +179,7 @@ pub struct BurnMetadata {
 }
 
 /// Record that can be saved by a [Recorder](Recorder).
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct BurnRecord<I> {
     /// Metadata of the record.
     pub metadata: BurnMetadata,

--- a/burn-import/onnx-tests/build.rs
+++ b/burn-import/onnx-tests/build.rs
@@ -1,4 +1,4 @@
-use burn_import::onnx::ModelGen;
+use burn_import::onnx::{ModelGen, RecordType};
 
 fn main() {
     // Re-run this build script if the onnx-tests directory changes.
@@ -34,6 +34,77 @@ fn main() {
         .input("tests/tanh/tanh.onnx")
         .input("tests/transpose/transpose.onnx")
         .out_dir("model/")
+        .run_from_script();
+
+    // The following tests are used to generate the model with different record types.
+    // (e.g. bincode, pretty_json, etc.) Do not need to add new tests here, just use the default
+    // record type to the ModelGen::new() call above.
+
+    ModelGen::new()
+        .input("tests/conv1d/conv1d.onnx")
+        .out_dir("model/named_mpk/")
+        .record_type(RecordType::NamedMpk)
+        .run_from_script();
+
+    ModelGen::new()
+        .input("tests/conv1d/conv1d.onnx")
+        .out_dir("model/named_mpk_half/")
+        .record_type(RecordType::NamedMpk)
+        .half_precision(true)
+        .run_from_script();
+
+    ModelGen::new()
+        .input("tests/conv1d/conv1d.onnx")
+        .out_dir("model/pretty_json/")
+        .record_type(RecordType::PrettyJson)
+        .run_from_script();
+
+    ModelGen::new()
+        .input("tests/conv1d/conv1d.onnx")
+        .out_dir("model/pretty_json_half/")
+        .record_type(RecordType::PrettyJson)
+        .half_precision(true)
+        .run_from_script();
+
+    ModelGen::new()
+        .input("tests/conv1d/conv1d.onnx")
+        .out_dir("model/named_mpk_gz/")
+        .record_type(RecordType::NamedMpkGz)
+        .run_from_script();
+
+    ModelGen::new()
+        .input("tests/conv1d/conv1d.onnx")
+        .out_dir("model/named_mpk_gz_half/")
+        .record_type(RecordType::NamedMpkGz)
+        .half_precision(true)
+        .run_from_script();
+
+    ModelGen::new()
+        .input("tests/conv1d/conv1d.onnx")
+        .out_dir("model/bincode/")
+        .record_type(RecordType::Bincode)
+        .run_from_script();
+
+    ModelGen::new()
+        .input("tests/conv1d/conv1d.onnx")
+        .out_dir("model/bincode_half/")
+        .record_type(RecordType::Bincode)
+        .half_precision(true)
+        .run_from_script();
+
+    ModelGen::new()
+        .input("tests/conv1d/conv1d.onnx")
+        .out_dir("model/bincode_embedded/")
+        .embed_states(true)
+        .record_type(RecordType::Bincode)
+        .run_from_script();
+
+    ModelGen::new()
+        .input("tests/conv1d/conv1d.onnx")
+        .out_dir("model/bincode_embedded_half/")
+        .embed_states(true)
+        .half_precision(true)
+        .record_type(RecordType::Bincode)
         .run_from_script();
 
     // panic!("Purposefully failing build to output logs.");

--- a/burn-import/onnx-tests/tests/record_type_tests.rs
+++ b/burn-import/onnx-tests/tests/record_type_tests.rs
@@ -5,34 +5,20 @@
 // For half precision, we use a different tolerance because the output is
 // different.
 
-macro_rules! include_model {
-    ($($mod_name:ident),*) => {
-        $(
-            pub mod $mod_name {
-                include!(concat!(env!("OUT_DIR"), "/model/", stringify!($mod_name), "/conv1d.rs"));
-            }
-        )*
-    };
-}
-
-include_model!(
-    named_mpk,
-    named_mpk_half,
-    pretty_json,
-    pretty_json_half,
-    named_mpk_gz,
-    named_mpk_gz_half,
-    bincode,
-    bincode_half,
-    bincode_embedded,
-    bincode_embedded_half
-);
-
 macro_rules! test_model {
     ($mod_name:ident) => {
         test_model!($mod_name, 1.0e-4); // Default tolerance
     };
     ($mod_name:ident, $tolerance:expr) => {
+        pub mod $mod_name {
+            include!(concat!(
+                env!("OUT_DIR"),
+                "/model/",
+                stringify!($mod_name),
+                "/conv1d.rs"
+            ));
+        }
+
         #[test]
         fn $mod_name() {
             // Initialize the model with weights (loaded from the exported file)
@@ -58,13 +44,9 @@ macro_rules! test_model {
 
 #[cfg(test)]
 mod tests {
-    use std::f64::consts;
-
-    use super::*;
-
     use burn::tensor::{Shape, Tensor};
-
     use float_cmp::ApproxEq;
+    use std::f64::consts;
 
     type Backend = burn_ndarray::NdArrayBackend<f32>;
 

--- a/burn-import/onnx-tests/tests/record_type_tests.rs
+++ b/burn-import/onnx-tests/tests/record_type_tests.rs
@@ -1,0 +1,81 @@
+// This test suite verifies that the exported models are compatible with the
+// different record types. It uses an existing model (conv1d.onnx) and exports
+// it with different record types. Then it loads the exported model and runs it
+// with the same input to verify that the output is the same.
+// For half precision, we use a different tolerance because the output is
+// different.
+
+macro_rules! include_model {
+    ($($mod_name:ident),*) => {
+        $(
+            pub mod $mod_name {
+                include!(concat!(env!("OUT_DIR"), "/model/", stringify!($mod_name), "/conv1d.rs"));
+            }
+        )*
+    };
+}
+
+include_model!(
+    named_mpk,
+    named_mpk_half,
+    pretty_json,
+    pretty_json_half,
+    named_mpk_gz,
+    named_mpk_gz_half,
+    bincode,
+    bincode_half,
+    bincode_embedded,
+    bincode_embedded_half
+);
+
+macro_rules! test_model {
+    ($mod_name:ident) => {
+        test_model!($mod_name, 1.0e-4); // Default tolerance
+    };
+    ($mod_name:ident, $tolerance:expr) => {
+        #[test]
+        fn $mod_name() {
+            // Initialize the model with weights (loaded from the exported file)
+            let model: $mod_name::Model<Backend> = $mod_name::Model::default();
+
+            // Run the model with pi as input for easier testing
+            let input = Tensor::<Backend, 3>::full([6, 4, 10], consts::PI);
+
+            let output = model.forward(input);
+
+            // test the output shape
+            let expected_shape: Shape<3> = Shape::from([6, 2, 7]);
+            assert_eq!(output.shape(), expected_shape);
+
+            // We are using the sum of the output tensor to test the correctness of the conv1d node
+            // because the output tensor is too large to compare with the expected tensor.
+            let output_sum = output.sum().into_scalar();
+            let expected_sum = -54.549_243; // from pytorch
+            assert!(expected_sum.approx_eq(output_sum, ($tolerance, 2)));
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use std::f64::consts;
+
+    use super::*;
+
+    use burn::tensor::{Shape, Tensor};
+
+    use float_cmp::ApproxEq;
+
+    type Backend = burn_ndarray::NdArrayBackend<f32>;
+
+    test_model!(named_mpk);
+    test_model!(named_mpk_half, 1.0e-2); // Reduce tolerance for half precision
+    test_model!(pretty_json);
+    test_model!(pretty_json_half, 1.0e-2); // Reduce tolerance for half precision
+    test_model!(named_mpk_gz);
+    test_model!(named_mpk_gz_half, 1.0e-2); // Reduce tolerance for half precision
+    test_model!(bincode);
+    test_model!(bincode_half, 1.0e-2); // Reduce tolerance for half precision
+    test_model!(bincode_embedded);
+    test_model!(bincode_embedded_half, 1.0e-2); // Reduce tolerance for half precision
+}

--- a/burn-import/src/burn/graph.rs
+++ b/burn-import/src/burn/graph.rs
@@ -4,12 +4,33 @@ use crate::burn::{
     TensorKind, TensorType,
 };
 use burn::record::{
-    BurnRecord, DefaultFileRecorder, FileRecorder, PrecisionSettings, PrettyJsonFileRecorder,
+    BinFileRecorder, BurnRecord, FileRecorder, NamedMpkFileRecorder, NamedMpkGzFileRecorder,
+    PrecisionSettings, PrettyJsonFileRecorder, Recorder,
 };
 use proc_macro2::TokenStream;
 use quote::quote;
-use serde::{ser::SerializeMap, Serialize};
-use std::{collections::HashMap, path::PathBuf};
+use serde::{
+    ser::{SerializeMap, SerializeTuple},
+    Serialize,
+};
+use std::{any::type_name, collections::HashMap, path::PathBuf};
+
+/// Type of the record to be saved.
+#[derive(Debug, Clone, Default, Copy)]
+pub enum RecordType {
+    /// Pretty JSON format (useful for debugging).
+    PrettyJson,
+
+    #[default]
+    /// Compressed Named MessagePack.
+    NamedMpkGz,
+
+    /// Uncompressed Named MessagePack.
+    NamedMpk,
+
+    /// Bincode format (useful for embedding and for no-std support).
+    Bincode,
+}
 
 /// Burn graph intermediate representation of modules and tensor operations.
 #[derive(Default, Debug)]
@@ -48,37 +69,111 @@ impl<PS: PrecisionSettings> BurnGraph<PS> {
     /// Save the state of each node in a record file.
     ///
     /// The `Default` trait will be implemented for the generated model, which will load the record
-    /// saved at the provided path.
+    /// saved at the provided path. In case of `embed_states` is true, the record will be embedded
+    /// in the generated code (useful for no-std support).
     ///
-    /// # Notes
+    /// # Arguments
     ///
-    /// The development argument will change the recorder used.
-    /// [pretty json](PrettyJsonFileRecorder) is used when development is true and [default](DefaultFileRecorder) is used otherwise.
+    /// * `out_file` - The path to the record file.
+    /// * `record_type` - The type of the record to be saved.
+    /// * `embed_states` - Embed the record in the generated code.
     ///
-    /// The precision type must be passed as `&str` and should be the same type definition as the
-    /// `PS` graph generic argument. [type_name](std::any::type_name) can't be used reliably for
-    /// that purpose.
+    /// # Panics
+    ///
+    /// Panics if the record type is not `RecordType::Bincode` and `embed_states` is `true`.
     pub fn with_record(
         mut self,
         out_file: PathBuf,
-        development: bool,
-        precision_ty_str: &str,
+        record_type: RecordType,
+        embed_states: bool,
     ) -> Self {
-        if development {
-            let recorder = PrettyJsonFileRecorder::<PS>::new();
-            self.register_record(
-                recorder,
-                out_file,
-                &format!("burn::record::PrettyJsonFileRecorder::<{precision_ty_str}>"),
-            );
-        } else {
-            let recorder = DefaultFileRecorder::<PS>::new();
-            self.register_record(
-                recorder,
-                out_file,
-                &format!("burn::record::DefaultFileRecorder::<{precision_ty_str}>"),
-            );
+        let precision_ty_str = extract_type_name_by_type::<PS>();
+        self.imports
+            .register(format!("burn::record::{precision_ty_str}"));
+
+        match record_type {
+            RecordType::PrettyJson => {
+                PrettyJsonFileRecorder::<PS>::new()
+                    .save_item(
+                        BurnRecord::new::<PrettyJsonFileRecorder<PS>>(StructMap(
+                            BurnGraphState::new(&self.nodes),
+                        )),
+                        out_file.clone(),
+                    )
+                    .unwrap();
+
+                assert!(
+                    !embed_states,
+                    "Embedding states is not supported for PrettyJsonFileRecorder."
+                );
+
+                self.register_record(
+                    out_file,
+                    embed_states,
+                    &format!("burn::record::PrettyJsonFileRecorder::<{precision_ty_str}>"),
+                );
+            }
+            RecordType::NamedMpkGz => {
+                NamedMpkGzFileRecorder::<PS>::new()
+                    .save_item(
+                        BurnRecord::new::<NamedMpkGzFileRecorder<PS>>(StructMap(
+                            BurnGraphState::new(&self.nodes),
+                        )),
+                        out_file.clone(),
+                    )
+                    .unwrap();
+
+                assert!(
+                    !embed_states,
+                    "Embedding states is not supported for NamedMpkGzFileRecorder."
+                );
+                self.register_record(
+                    out_file,
+                    embed_states,
+                    &format!("burn::record::NamedMpkGzFileRecorder::<{precision_ty_str}>"),
+                );
+            }
+
+            RecordType::NamedMpk => {
+                NamedMpkFileRecorder::<PS>::new()
+                    .save_item(
+                        BurnRecord::new::<NamedMpkGzFileRecorder<PS>>(StructMap(
+                            BurnGraphState::new(&self.nodes),
+                        )),
+                        out_file.clone(),
+                    )
+                    .unwrap();
+
+                assert!(
+                    !embed_states,
+                    "Embedding states is not supported for NamedMpkFileRecorder."
+                );
+
+                self.register_record(
+                    out_file,
+                    embed_states,
+                    &format!("burn::record::NamedMpkFileRecorder::<{precision_ty_str}>"),
+                );
+            }
+
+            RecordType::Bincode => {
+                BinFileRecorder::<PS>::new()
+                    .save_item(
+                        BurnRecord::new::<BinFileRecorder<PS>>(StructTuple(BurnGraphState::new(
+                            &self.nodes,
+                        ))),
+                        out_file.clone(),
+                    )
+                    .unwrap();
+
+                self.register_record(
+                    out_file,
+                    embed_states,
+                    &format!("burn::record::BinFileRecorder::<{precision_ty_str}>"),
+                );
+            }
         }
+
         self
     }
 
@@ -240,33 +335,49 @@ impl<PS: PrecisionSettings> BurnGraph<PS> {
             });
     }
 
-    fn register_record<FR: FileRecorder>(
-        &mut self,
-        recorder: FR,
-        file: PathBuf,
-        recorder_str: &str,
-    ) {
+    fn register_record(&mut self, file: PathBuf, embed_states: bool, recorder_str: &str) {
         self.imports.register("burn::record::Recorder");
 
-        let state = BurnGraphState::new(&self.nodes);
-        recorder
-            .save_item(BurnRecord::new::<FR>(state), file.clone())
-            .unwrap();
-
         let recorder_ty = syn::parse_str::<syn::Type>(recorder_str).unwrap();
-        let file = file.to_str();
 
-        // Add default implementation
-        self.default = Some(quote! {
-            impl<B: Backend> Default for Model<B> {
-                fn default() -> Self {
-                    let record = #recorder_ty::new()
-                        .load(#file.into())
-                        .expect("Record file to exist.");
-                    Self::new_with(record)
+        if embed_states {
+            // NOTE: Bincode format is used for embedding states for now.
+
+            let precision = extract_type_name_by_type::<PS>();
+            let precision_ty = syn::parse_str::<syn::Type>(&precision).unwrap();
+            self.imports.register("burn::record::BinBytesRecorder");
+
+            let mut file = file;
+            file.set_extension(BinFileRecorder::<PS>::file_extension());
+            let file = file.to_str().unwrap();
+            self.default = Some(quote! {
+                static EMBEDDED_STATES: &[u8] = include_bytes!(#file);
+
+                impl<B: Backend> Default for Model<B> {
+                    fn default() -> Self {
+                        let record = BinBytesRecorder::<#precision_ty>::default()
+                        .load(EMBEDDED_STATES.to_vec())
+                        .expect("Failed to decode state");
+
+                        Self::new_with(record)
+                    }
                 }
-            }
-        });
+
+            });
+        } else {
+            // Add default implementation
+            let file = file.to_str().unwrap();
+            self.default = Some(quote! {
+                impl<B: Backend> Default for Model<B> {
+                    fn default() -> Self {
+                        let record = #recorder_ty::new()
+                            .load(#file.into())
+                            .expect("Record file to exist.");
+                        Self::new_with(record)
+                    }
+                }
+            });
+        }
     }
 
     fn codegen_struct(&self) -> TokenStream {
@@ -472,17 +583,34 @@ impl<PS: PrecisionSettings> BurnGraph<PS> {
     }
 }
 
-#[derive(new)]
+#[derive(new, Debug)]
 struct BurnGraphState<'a, PS: PrecisionSettings> {
     nodes: &'a Vec<Node<PS>>,
 }
 
-impl<'a, PS: PrecisionSettings> Serialize for BurnGraphState<'a, PS> {
+/// For custom serialization of the graph state in module struct, there are generally
+/// two options:
+/// 1. Serialize the nodes as a map with the node name as the key and the node as the value.
+/// 2. Serialize the nodes as a tuple.
+///
+/// PrettyJson, NamedMpk, and NamedMpkGz use the first option and this struct is used for that.
+struct StructMap<'a, PS: PrecisionSettings>(BurnGraphState<'a, PS>);
+
+/// For custom serialization of the graph state in module struct, there are generally
+/// two options:
+/// 1. Serialize the nodes as a map with the node name as the key and the node as the value.
+/// 2. Serialize the nodes as a tuple.
+///
+/// Mpk, and Bincode use the second option and this struct is used for that.
+struct StructTuple<'a, PS: PrecisionSettings>(BurnGraphState<'a, PS>);
+
+impl<'a, PS: PrecisionSettings> Serialize for StructMap<'a, PS> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
         let nodes_with_names = self
+            .0
             .nodes
             .iter()
             .filter_map(|node| node.field_type().map(|ty| (node, ty.name().clone())))
@@ -495,4 +623,34 @@ impl<'a, PS: PrecisionSettings> Serialize for BurnGraphState<'a, PS> {
 
         map.end()
     }
+}
+
+impl<'a, PS: PrecisionSettings> Serialize for StructTuple<'a, PS> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let nodes_with_names = self
+            .0
+            .nodes
+            .iter()
+            .filter_map(|node| node.field_type().map(|ty| (node, ty.name().clone())))
+            .collect::<Vec<_>>();
+        let mut map = serializer.serialize_tuple(nodes_with_names.len())?;
+
+        for (node, _name) in nodes_with_names.iter() {
+            map.serialize_element(&node)?;
+        }
+
+        map.end()
+    }
+}
+
+fn extract_type_name_by_type<T: ?Sized>() -> String {
+    let full_type_name = type_name::<T>();
+    full_type_name
+        .rsplit("::")
+        .next()
+        .unwrap_or(full_type_name)
+        .to_string()
 }

--- a/burn-import/src/burn/graph.rs
+++ b/burn-import/src/burn/graph.rs
@@ -596,15 +596,12 @@ struct BurnGraphState<'a, PS: PrecisionSettings> {
 ///
 /// Notably, this approach is utilized by serialization formats such as PrettyJson, NamedMpk,
 /// and NamedMpkGz.
+///
+/// # Notes
+///
+/// Mpk and Bincode cannot use this method because they do not support serializing maps.
+/// Instead, they use the `StructTuple` serialization strategy (to avoid memory overhead presumably).
 struct StructMap<'a, PS: PrecisionSettings>(BurnGraphState<'a, PS>);
-
-/// Represents a custom serialization strategy for the graph state in the module struct.
-///
-/// In contrast to `StructMap`, this struct serializes the graph state using a tuple format.
-/// Each node is simply serialized as an element of the tuple without explicit naming.
-///
-/// Serialization formats such as Mpk and Bincode employ this method.
-struct StructTuple<'a, PS: PrecisionSettings>(BurnGraphState<'a, PS>);
 
 impl<'a, PS: PrecisionSettings> Serialize for StructMap<'a, PS> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -626,6 +623,19 @@ impl<'a, PS: PrecisionSettings> Serialize for StructMap<'a, PS> {
         map.end()
     }
 }
+
+/// Represents a custom serialization strategy for the graph state in the module struct.
+///
+/// In contrast to `StructMap`, this struct serializes the graph state using a tuple format.
+/// Each node is simply serialized as an element of the tuple without explicit naming.
+///
+/// Serialization formats such as Mpk and Bincode employ this method.
+///
+/// # Notes
+///
+/// PrettyJson, NamedMpk, and NamedMpkGz cannot use this method because they do not support
+/// serializing tuples. Instead, they use the `StructMap` serialization strategy.
+struct StructTuple<'a, PS: PrecisionSettings>(BurnGraphState<'a, PS>);
 
 impl<'a, PS: PrecisionSettings> Serialize for StructTuple<'a, PS> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/burn-import/src/burn/node/base.rs
+++ b/burn-import/src/burn/node/base.rs
@@ -70,7 +70,7 @@ pub trait NodeCodegen<PS: PrecisionSettings>: std::fmt::Debug {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Node<PS: PrecisionSettings> {
     AvgPool2d(AvgPool2dNode),
     BatchNorm(BatchNormNode<PS>),

--- a/burn-import/src/logger.rs
+++ b/burn-import/src/logger.rs
@@ -3,8 +3,10 @@ use tracing_core::LevelFilter;
 
 pub fn init_log() -> Result<(), Box<dyn Error + Send + Sync>> {
     let result = tracing_subscriber::fmt()
-        .with_max_level(LevelFilter::INFO)
+        .with_max_level(LevelFilter::DEBUG)
+        .without_time()
         .try_init();
+
     if result.is_ok() {
         update_panic_hook();
     }

--- a/burn-import/src/main.rs
+++ b/burn-import/src/main.rs
@@ -1,4 +1,4 @@
-use burn_import::onnx::ModelGen;
+use burn_import::onnx::{ModelGen, RecordType};
 
 /// Takes an ONNX file and generates a model from it
 fn main() {
@@ -11,6 +11,7 @@ fn main() {
     ModelGen::new()
         .input(onnx_file.as_str())
         .development(true)
+        .record_type(RecordType::PrettyJson)
         .out_dir(output_dir.as_str())
         .run_from_cli();
 }

--- a/examples/onnx-inference/Cargo.toml
+++ b/examples/onnx-inference/Cargo.toml
@@ -7,11 +7,13 @@ publish = false
 version = "0.10.0"
 
 [features]
-default = ["burn/dataset-sqlite-bundled"]
+default = ["embedded-model"]
+
+embedded-model = []
 
 [dependencies]
-burn = {path = "../../burn", features=["ndarray"]}
-serde = {workspace = true}
+burn = { path = "../../burn", features = ["ndarray", "dataset-sqlite-bundled"] }
+serde = { workspace = true }
 
 [build-dependencies]
-burn-import = {path = "../../burn-import"}
+burn-import = { path = "../../burn-import" }

--- a/examples/onnx-inference/README.md
+++ b/examples/onnx-inference/README.md
@@ -24,6 +24,13 @@ See the image online, click the link below:
 https://datasets-server.huggingface.co/assets/mnist/--/mnist/test/15/image/image.jpg
 ```
 
+## Feature Flags
+
+- `embedded-model` (default) - Embed the model weights into the binary. This is useful for small
+  models (e.g. MNIST) but not recommended for very large models because it will increase the binary
+  size significantly and will consume a lot of memory at runtime. If you do not use this feature,
+  the model weights will be loaded from a binary file at runtime.
+
 ## How to import
 
 1. Create `model` directory under `src`
@@ -57,8 +64,7 @@ https://datasets-server.huggingface.co/assets/mnist/--/mnist/test/15/image/image
 
    ```
 
-6. Add your model to `src/bin` as a new file, in this specific case we have
-called it `mnist.rs`:
+6. Add your model to `src/bin` as a new file, in this specific case we have called it `mnist.rs`:
 
    ```rust
    use burn::tensor;

--- a/examples/onnx-inference/build.rs
+++ b/examples/onnx-inference/build.rs
@@ -1,9 +1,21 @@
-use burn_import::onnx::ModelGen;
+use burn_import::onnx::{ModelGen, RecordType};
 
 fn main() {
     // Generate the model code from the ONNX file.
-    ModelGen::new()
-        .input("src/model/mnist.onnx")
-        .out_dir("model/")
-        .run_from_script();
+
+    if cfg!(feature = "embedded-model") {
+        // If the embedded-model, then model is bundled into the binary.
+        ModelGen::new()
+            .input("src/model/mnist.onnx")
+            .out_dir("model/")
+            .record_type(RecordType::Bincode)
+            .embed_states(true)
+            .run_from_script();
+    } else {
+        // If not embedded-model, then model is loaded from the file system (default).
+        ModelGen::new()
+            .input("src/model/mnist.onnx")
+            .out_dir("model/")
+            .run_from_script();
+    }
 }

--- a/xtask/src/runchecks.rs
+++ b/xtask/src/runchecks.rs
@@ -3,21 +3,6 @@
 //! It is used to check that the code compiles and passes all tests.
 //!
 //! It is also used to check that the code is formatted correctly and passes clippy.
-//!
-//! To build this script, run the following command:
-//!
-//! rustc scripts/run-checks.rs --crate-type bin --out-dir scripts
-//!
-//! To run the script:
-//!
-//! ./scripts/run-checks environment
-//!
-//! where `environment` can assume **ONLY** the following values:
-//!     - `std` to perform checks using `libstd`
-//!     - `no_std` to perform checks on an embedded environment using `libcore`
-//!     - `typos` to check typos in the source code
-//!     - `examples` to check the examples compile
-
 use std::env;
 use std::process::{Child, Command, Stdio};
 use std::str;
@@ -270,6 +255,10 @@ fn check_examples() {
     std::fs::read_dir("examples").unwrap().for_each(|dir| {
         let dir = dir.unwrap();
         let path = dir.path();
+        // Skip if not a directory
+        if !path.is_dir() {
+            return;
+        }
         if path.file_name().unwrap().to_str().unwrap() == "notebook" {
             // not a crate
             return;


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirm that `run-checks` script has been executed.

### Related Issues/PRs

_Provide links to relevant issues and dependent PRs._

### Changes

This adds support for all record types supported by Burn. Also this includes support for embedding and precision.

### Testing

Added new tests and made sure the existing pass using run-checks