### PR TITLE
Fix dataset count slowness

### DIFF
--- a/burn-dataset/src/dataset/mod.rs
+++ b/burn-dataset/src/dataset/mod.rs
@@ -6,7 +6,7 @@ mod iterator;
 #[cfg(any(feature = "sqlite", feature = "sqlite-bundled"))]
 mod sqlite;
 
-#[cfg(feature = "fake")]
+#[cfg(any(test, feature = "fake"))]
 pub use self::fake::*;
 pub use base::*;
 pub use in_memory::*;


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirm that `run-checks` script has been executed.

### Related Issues/PRs

Fixes #811

### Changes

Instead of using select count(*) from split, we are replacing with select coalesce(max(row_id), 0) from which is instantaneous for very large databases (tested for 260GB db).

The coalesce(max(row_id), 0) returns 0 if the table is empty, otherwise it returns the max row_id, which corresponds to the number of rows in the table. The main assumption, which always holds true, is that the row_id is always increasing and there are no gaps. This is true for all the datasets that we are using, otherwise row_id will not correspond to the index (+1). row_id must not have gaps. If someone remove rows manually, they should update the row_ids as well.

We are not using unique index for row_id because it slows down insertion considerably (post creation is also very slow) and it is unnecessary for the dataset usage with always true assumptions about row_id ( row_id will always correspond to index (+1). )

### Testing

1. Tested MNIST example by recreating db.
2. Tested for very large table. Here is a python script to great a db locally:

```python
#!/usr/bin/env python3

import sqlite3

STRING = "abcdefghijklmnopqrstuvwxyz"*100


def generate_data(db_name="large_data.db", table_name="big_data", target_size_gb=100):
    conn = sqlite3.connect(db_name)
    c = conn.cursor()

    # Turn off journalling for faster insertion
    c.execute("PRAGMA journal_mode=OFF")

    # Create table
    c.execute(f'''CREATE TABLE IF NOT EXISTS {table_name} (
        row_id INTEGER PRIMARY KEY,
        data TEXT NOT NULL
    )''')

    i = 0

    while i < 40_000_000:
        c.execute(
            f"INSERT INTO {table_name} (data) VALUES (?)", (STRING,))

        # Commit every 1000 inserts for efficiency
        if i % 1000 == 0:
            conn.commit()
        i += 1

    conn.commit()
    conn.close()


if __name__ == "__main__":
    generate_data()

```