### PR TITLE
only use gix-tempfile if on sqlite

### DIFF
--- a/burn-dataset/Cargo.toml
+++ b/burn-dataset/Cargo.toml
@@ -19,8 +19,8 @@ audio = [
 
 fake = ["dep:fake"]
 
-sqlite = ["__sqlite-shared", "dep:rusqlite"]
-sqlite-bundled = ["__sqlite-shared", "rusqlite/bundled"]
+sqlite = ["__sqlite-shared", "dep:rusqlite", "dep:gix-tempfile"]
+sqlite-bundled = ["__sqlite-shared", "rusqlite/bundled", "dep:gix-tempfile"]
 
 # internal
 __sqlite-shared = ["dep:r2d2", "dep:r2d2_sqlite", "dep:serde_rusqlite", "dep:image"]
@@ -30,7 +30,7 @@ csv = {workspace = true}
 derive-new = {workspace = true}
 dirs = {workspace = true}
 fake = {workspace = true, optional = true}
-gix-tempfile = {workspace = true}
+gix-tempfile = {workspace = true, optional = true}
 hound = {version = "3.5.0", optional = true}
 image = {version = "0.24.6", features = ["png"], optional = true}
 r2d2 = {workspace = true, optional = true}

--- a/burn-dataset/Cargo.toml
+++ b/burn-dataset/Cargo.toml
@@ -19,11 +19,11 @@ audio = [
 
 fake = ["dep:fake"]
 
-sqlite = ["__sqlite-shared", "dep:rusqlite", "dep:gix-tempfile"]
-sqlite-bundled = ["__sqlite-shared", "rusqlite/bundled", "dep:gix-tempfile"]
+sqlite = ["__sqlite-shared", "dep:rusqlite"]
+sqlite-bundled = ["__sqlite-shared", "rusqlite/bundled"]
 
 # internal
-__sqlite-shared = ["dep:r2d2", "dep:r2d2_sqlite", "dep:serde_rusqlite", "dep:image"]
+__sqlite-shared = ["dep:r2d2", "dep:r2d2_sqlite", "dep:serde_rusqlite", "dep:image", "dep:gix-tempfile"]
 
 [dependencies]
 csv = {workspace = true}


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [?] Confirm that `run-checks` script has been executed.

`./run-checks.sh no-std` passes, but `./run-checks.sh std` fails with

```
// buncha other failing tests omitted
test kernel::matmul::tiling2d::tile::tests::test_matmul_tiling_2d_n_larger_than_m ... FAILED
error: test failed, to rerun pass `-p burn-wgpu --lib`

Caused by:
  process didn't exit successfully: `/home/alex/burn/target/debug/deps/burn_wgpu-84cde3781cf8711c --color=always` (signal: 11, SIGSEGV: invalid memory reference)
```

However, the same occurs on `main` without my change, so I'm chalking it up to 'yer machine's effed'.

### Changes

Problem: I want to run burn-dataset in the browser, but it has a dependency on `gix-tempfile` which definitely doesn't work in the browser.

Solution: Use `gix-tempfile` only if the `sqlite` feature is used.

### Testing

Adding

```
burn = {path = "../../burn", default-features = false, features = ["std", "train-minimal", "autodiff", "dataset-minimal", "ndarray"]} # extra features cause I want them too
getrandom = { version = "0.2", features = ["js"] }
```
to https://github.com/burn-rs/burn/blob/main/examples/mnist-inference-web/Cargo.toml and running `wasm-pack build --target web` works. Is that enough? Hell if I know - this is the second time I've ever touched Rust.