### PR TITLE
Use thread-local RNG to generate IDs

### DIFF
--- a/burn-common/src/id.rs
+++ b/burn-common/src/id.rs
@@ -1,4 +1,4 @@
-use crate::rand::{get_seeded_rng, Rng, SEED};
+use crate::rand::gen_random;
 use alloc::string::{String, ToString};
 use uuid::{Builder, Bytes};
 
@@ -8,15 +8,7 @@ pub struct IdGenerator {}
 impl IdGenerator {
     /// Generates a new ID in the form of a UUID.
     pub fn generate() -> String {
-        let mut seed = SEED.lock().unwrap();
-        let mut rng = if let Some(rng_seeded) = seed.as_ref() {
-            rng_seeded.clone()
-        } else {
-            get_seeded_rng()
-        };
-
-        let random_bytes: Bytes = rng.gen();
-        *seed = Some(rng);
+        let random_bytes: Bytes = gen_random();
 
         let uuid = Builder::from_random_bytes(random_bytes).into_uuid();
 

--- a/burn-common/src/rand.rs
+++ b/burn-common/src/rand.rs
@@ -1,13 +1,9 @@
 pub use rand::{rngs::StdRng, Rng, SeedableRng};
 
-#[cfg(feature = "std")]
-use std::sync::Mutex;
-
-#[cfg(not(feature = "std"))]
-use crate::stub::Mutex;
-
 #[cfg(not(feature = "std"))]
 use const_random::const_random;
+use rand::distributions::Standard;
+use rand::prelude::Distribution;
 
 /// Returns a seeded random number generator using entropy.
 #[cfg(feature = "std")]
@@ -24,4 +20,28 @@ pub fn get_seeded_rng() -> StdRng {
     StdRng::seed_from_u64(GENERATED_SEED)
 }
 
-pub(crate) static SEED: Mutex<Option<StdRng>> = Mutex::new(None);
+/// Generates random data from a thread-local RNG.
+#[cfg(feature = "std")]
+#[inline]
+pub fn gen_random<T>() -> T
+where
+    Standard: Distribution<T>,
+{
+    rand::thread_rng().gen()
+}
+
+/// Generates random data from a mutex-protected RNG.
+#[cfg(not(feature = "std"))]
+#[inline]
+pub fn gen_random<T>() -> T
+where
+    Standard: Distribution<T>,
+{
+    use crate::stub::Mutex;
+    static RNG: Mutex<Option<StdRng>> = Mutex::new(None);
+    let mut rng = RNG.lock().unwrap();
+    if rng.is_none() {
+        *rng = Some(get_seeded_rng());
+    }
+    rng.as_mut().unwrap().gen()
+}


### PR DESCRIPTION
We've been exploring dividing our data set up into multiple batches, and training those batches in parallel. I noticed that performance did not scale with core count, and after some digging, found that this was mainly due to the Mutex being used to generate IDs. With the following change, training across 16 cores went from 21s to 4.2s.

thread_rng was previously discussed on #703, but I don't believe that applies here, as this is just used for UUID creation.

Using string UUIDs here is also not the most efficient - would there be any interest in a follow-up PR that uses the bytes directly instead of converting them to a string?

## Pull Request Template

### Checklist

- [x] Confirm that `run-checks` script has been executed.

I'm getting intermittent flakes with burn_wgpu, that happened even before this change. Maybe my GPU/driver?

```
---- tests::module_backward::tests::test_embedding_backward stdout ----
thread 'tests::module_backward::tests::test_embedding_backward' panicked at 'assertion failed: `(left == right)`
  left: `Data { value: [NaN, NaN, NaN, NaN, NaN, NaN], shape: Shape { dims: [2, 3] } }`,
 right: `Data { value: [3.0, 9.0, 7.0, 21.0, 35.0, 27.0], shape: Shape { dims: [2, 3] } }`', burn-wgpu/src/lib.rs:48:5
```
