### PR TITLE
Fix flaky init

### DIFF
--- a/burn-wgpu/src/kernel/index/select.rs
+++ b/burn-wgpu/src/kernel/index/select.rs
@@ -53,10 +53,7 @@ pub(crate) fn select_assign<E: WgpuElement, I: WgpuElement, const D: usize>(
 ) -> WgpuTensor<E, D> {
     let tensor = match tensor.can_mut() {
         true => tensor,
-        false => {
-            println!("Copy");
-            tensor.copy()
-        }
+        false => tensor.copy(),
     };
 
     let mut info = build_info(&[&tensor, &value]);

--- a/burn-wgpu/src/kernel/index/select.rs
+++ b/burn-wgpu/src/kernel/index/select.rs
@@ -53,7 +53,10 @@ pub(crate) fn select_assign<E: WgpuElement, I: WgpuElement, const D: usize>(
 ) -> WgpuTensor<E, D> {
     let tensor = match tensor.can_mut() {
         true => tensor,
-        false => tensor.copy(),
+        false => {
+            println!("Copy");
+            tensor.copy()
+        }
     };
 
     let mut info = build_info(&[&tensor, &value]);

--- a/burn-wgpu/src/kernel/unary_scalar.rs
+++ b/burn-wgpu/src/kernel/unary_scalar.rs
@@ -74,6 +74,19 @@ macro_rules! unary_scalar_inplace {
 
     (
         $struct:ident,
+        body $body:expr
+    ) => {
+        pub struct $struct;
+
+        impl $crate::kernel::StaticKernelSource for $struct {
+            fn source() -> $crate::kernel::SourceTemplate {
+                $crate::kernel::UnaryScalarInplaceRaw::source().register("body", $body)
+            }
+        }
+    };
+
+    (
+        $struct:ident,
         func $func:expr
     ) => {
         pub struct $struct;

--- a/burn-wgpu/src/ops/float_ops.rs
+++ b/burn-wgpu/src/ops/float_ops.rs
@@ -4,11 +4,11 @@ use crate::kernel::{
     self, unary_default, unary_inplace_default, unary_scalar_default, unary_scalar_inplace_default,
 };
 
-use crate::unary_scalar_inplace;
 use crate::{
     element::{FloatElement, IntElement},
     unary, unary_inplace, unary_scalar, GraphicsApi, WgpuBackend,
 };
+use crate::{unary_scalar_inplace, WgpuDevice};
 use burn_tensor::{ops::TensorOps, Data, Distribution, Shape};
 use burn_tensor::{ElementConversion, Reader};
 
@@ -83,6 +83,14 @@ where
 
     fn zeros<const D: usize>(shape: Shape<D>, device: &Device<Self>) -> FloatTensor<Self, D> {
         numeric::zeros::<G, F, D>(shape, device)
+    }
+
+    fn full<const D: usize>(
+        shape: Shape<D>,
+        fill_value: FloatElem<Self>,
+        device: &WgpuDevice,
+    ) -> FloatTensor<Self, D> {
+        numeric::full::<G, F, D>(shape, device, fill_value)
     }
 
     fn ones<const D: usize>(shape: Shape<D>, device: &Device<Self>) -> FloatTensor<Self, D> {


### PR DESCRIPTION
Some of the tests were flaky, and I suspect the problem came from unreliable initialization in `burn-wgpu`. The problem comes from the fact that `zeros` was achieved by multiplying an empty tensor by zero. However, the empty tensor might have invalid numbers in it, or NaN, which would make the `zeros` or `ones` function return NaN as well. The fix is pretty simple: create a `Full` kernel and use it to initialize tensors. This reduces the number of kernels launched and avoids uninitialized memory from causing numerical problems. I wasn't able to reproduce the flaky test after the change.