### PR TITLE
Use a u64 counter for autodiff NodeIDs

### DIFF
--- a/burn-autodiff/src/grads.rs
+++ b/burn-autodiff/src/grads.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 /// Gradient identifier.
-pub type GradID = String;
+pub type GradID = u64;
 
 /// Gradients container used during the backward pass.
 pub struct Gradients {
@@ -80,13 +80,11 @@ impl Gradients {
         value: TensorPrimitive<B, D>,
     ) {
         if let Some(tensor_old) = self.container.remove::<B, D>(&node.id.value) {
-            self.container.register(
-                node.id.value.clone(),
-                Tensor::from_primitive(value).add(tensor_old),
-            );
+            self.container
+                .register(node.id.value, Tensor::from_primitive(value).add(tensor_old));
         } else {
             self.container
-                .register::<B, D>(node.id.value.clone(), Tensor::from_primitive(value));
+                .register::<B, D>(node.id.value, Tensor::from_primitive(value));
         }
     }
 }

--- a/burn-autodiff/src/graph/node.rs
+++ b/burn-autodiff/src/graph/node.rs
@@ -33,9 +33,11 @@ impl NodeID {
     /// Create a unique [node id](NodeID).
     pub fn new() -> Self {
         static COUNTER: AtomicU64 = AtomicU64::new(0);
-        Self {
-            value: COUNTER.fetch_add(1, Ordering::Relaxed),
+        let value = COUNTER.fetch_add(1, Ordering::Relaxed);
+        if value == u64::MAX {
+            panic!("NodeID overflowed");
         }
+        Self { value }
     }
 }
 

--- a/burn-autodiff/src/graph/node.rs
+++ b/burn-autodiff/src/graph/node.rs
@@ -1,6 +1,5 @@
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-
-use burn_common::id::IdGenerator;
 
 use super::Requirement;
 
@@ -27,14 +26,15 @@ impl Node {
 /// Unique identifier generated for each [node](Node).
 #[derive(Clone, Hash, PartialEq, Eq, Debug)]
 pub struct NodeID {
-    pub value: String,
+    pub value: u64,
 }
 
 impl NodeID {
     /// Create a unique [node id](NodeID).
     pub fn new() -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
         Self {
-            value: IdGenerator::generate(),
+            value: COUNTER.fetch_add(1, Ordering::Relaxed),
         }
     }
 }


### PR DESCRIPTION
I measure an approximate 13.6% performance boost in our crate from this change.

## Pull Request Template

### Checklist

- [x] Confirm that `run-checks` script has been executed.

### Related Issues/PRs

#839
_Provide links to relevant issues and dependent PRs._

### Changes

_Summarize the problem being addressed and your solution._

### Testing

_Describe how these changes have been tested._
