### PR TITLE
removed batch_size field from GRU and LSTM

### DIFF
--- a/burn-core/src/nn/rnn/gru.rs
+++ b/burn-core/src/nn/rnn/gru.rs
@@ -23,8 +23,6 @@ pub struct GruConfig {
     /// Gru initializer
     #[config(default = "Initializer::XavierNormal{gain:1.0}")]
     pub initializer: Initializer,
-    /// The batch size.
-    pub batch_size: usize,
 }
 
 /// The Gru module. This implementation is for a unidirectional, stateless, Gru.
@@ -33,7 +31,6 @@ pub struct Gru<B: Backend> {
     update_gate: GateController<B>,
     reset_gate: GateController<B>,
     new_gate: GateController<B>,
-    batch_size: usize,
     d_hidden: usize,
 }
 
@@ -65,7 +62,6 @@ impl GruConfig {
             update_gate,
             reset_gate,
             new_gate,
-            batch_size: self.batch_size,
             d_hidden: self.d_hidden,
         }
     }
@@ -89,7 +85,6 @@ impl GruConfig {
                 record.reset_gate,
             ),
             new_gate: gate_controller::GateController::new_with(&linear_config, record.new_gate),
-            batch_size: self.batch_size,
             d_hidden: self.d_hidden,
         }
     }
@@ -111,11 +106,12 @@ impl<B: Backend> Gru<B> {
         batched_input: Tensor<B, 3>,
         state: Option<Tensor<B, 3>>,
     ) -> Tensor<B, 3> {
+        let batch_size = batched_input.shape().dims[0];
         let seq_length = batched_input.shape().dims[1];
 
         let mut hidden_state = match state {
             Some(state) => state,
-            None => Tensor::zeros([self.batch_size, seq_length, self.d_hidden]),
+            None => Tensor::zeros([batch_size, seq_length, self.d_hidden]),
         };
 
         for (t, (input_t, hidden_t)) in batched_input
@@ -146,7 +142,7 @@ impl<B: Backend> Gru<B> {
                 + update_values.clone().mul(hidden_t);
 
             hidden_state = hidden_state.slice_assign(
-                [0..self.batch_size, t..(t + 1), 0..self.d_hidden],
+                [0..batch_size, t..(t + 1), 0..self.d_hidden],
                 state_vector.clone().unsqueeze(),
             );
         }
@@ -210,7 +206,7 @@ mod tests {
     #[test]
     fn tests_forward_single_input_single_feature() {
         TestBackend::seed(0);
-        let config = GruConfig::new(1, 1, false, 1);
+        let config = GruConfig::new(1, 1, false);
         let mut gru = config.init::<TestBackend>();
 
         fn create_gate_controller(

--- a/burn-core/src/nn/rnn/gru.rs
+++ b/burn-core/src/nn/rnn/gru.rs
@@ -106,8 +106,7 @@ impl<B: Backend> Gru<B> {
         batched_input: Tensor<B, 3>,
         state: Option<Tensor<B, 3>>,
     ) -> Tensor<B, 3> {
-        let batch_size = batched_input.shape().dims[0];
-        let seq_length = batched_input.shape().dims[1];
+        let [batch_size, seq_length, _] = batched_input.shape().dims;
 
         let mut hidden_state = match state {
             Some(state) => state,

--- a/burn-core/src/nn/rnn/lstm.rs
+++ b/burn-core/src/nn/rnn/lstm.rs
@@ -122,8 +122,7 @@ impl<B: Backend> Lstm<B> {
         batched_input: Tensor<B, 3>,
         state: Option<(Tensor<B, 2>, Tensor<B, 2>)>,
     ) -> (Tensor<B, 3>, Tensor<B, 3>) {
-        let batch_size = batched_input.shape().dims[0];
-        let seq_length = batched_input.shape().dims[1];
+        let [batch_size, seq_length, _] = batched_input.shape().dims;
         let mut batched_cell_state = Tensor::zeros([batch_size, seq_length, self.d_hidden]);
         let mut batched_hidden_state = Tensor::zeros([batch_size, seq_length, self.d_hidden]);
 

--- a/burn-core/src/nn/rnn/lstm.rs
+++ b/burn-core/src/nn/rnn/lstm.rs
@@ -23,8 +23,6 @@ pub struct LstmConfig {
     /// Lstm initializer
     #[config(default = "Initializer::XavierNormal{gain:1.0}")]
     pub initializer: Initializer,
-    /// The batch size.
-    pub batch_size: usize,
 }
 
 /// The Lstm module. This implementation is for a unidirectional, stateless, Lstm.
@@ -34,7 +32,6 @@ pub struct Lstm<B: Backend> {
     forget_gate: GateController<B>,
     output_gate: GateController<B>,
     cell_gate: GateController<B>,
-    batch_size: usize,
     d_hidden: usize,
 }
 
@@ -73,7 +70,6 @@ impl LstmConfig {
             forget_gate,
             output_gate,
             cell_gate,
-            batch_size: self.batch_size,
             d_hidden: self.d_hidden,
         }
     }
@@ -101,7 +97,6 @@ impl LstmConfig {
                 record.output_gate,
             ),
             cell_gate: gate_controller::GateController::new_with(&linear_config, record.cell_gate),
-            batch_size: self.batch_size,
             d_hidden: self.d_hidden,
         }
     }
@@ -127,15 +122,16 @@ impl<B: Backend> Lstm<B> {
         batched_input: Tensor<B, 3>,
         state: Option<(Tensor<B, 2>, Tensor<B, 2>)>,
     ) -> (Tensor<B, 3>, Tensor<B, 3>) {
+        let batch_size = batched_input.shape().dims[0];
         let seq_length = batched_input.shape().dims[1];
-        let mut batched_cell_state = Tensor::zeros([self.batch_size, seq_length, self.d_hidden]);
-        let mut batched_hidden_state = Tensor::zeros([self.batch_size, seq_length, self.d_hidden]);
+        let mut batched_cell_state = Tensor::zeros([batch_size, seq_length, self.d_hidden]);
+        let mut batched_hidden_state = Tensor::zeros([batch_size, seq_length, self.d_hidden]);
 
         let (mut cell_state, mut hidden_state) = match state {
             Some((cell_state, hidden_state)) => (cell_state, hidden_state),
             None => (
-                Tensor::zeros([self.batch_size, self.d_hidden]),
-                Tensor::zeros([self.batch_size, self.d_hidden]),
+                Tensor::zeros([batch_size, self.d_hidden]),
+                Tensor::zeros([batch_size, self.d_hidden]),
             ),
         };
 
@@ -162,11 +158,11 @@ impl<B: Backend> Lstm<B> {
 
             // store the state for this timestep
             batched_cell_state = batched_cell_state.slice_assign(
-                [0..self.batch_size, t..(t + 1), 0..self.d_hidden],
+                [0..batch_size, t..(t + 1), 0..self.d_hidden],
                 cell_state.clone().unsqueeze(),
             );
             batched_hidden_state = batched_hidden_state.slice_assign(
-                [0..self.batch_size, t..(t + 1), 0..self.d_hidden],
+                [0..batch_size, t..(t + 1), 0..self.d_hidden],
                 hidden_state.clone().unsqueeze(),
             );
         }
@@ -224,7 +220,7 @@ mod tests {
     fn test_with_uniform_initializer() {
         TestBackend::seed(0);
 
-        let config = LstmConfig::new(5, 5, false, 2)
+        let config = LstmConfig::new(5, 5, false)
             .with_initializer(Initializer::Uniform { min: 0.0, max: 1.0 });
         let lstm = config.init::<TestBackend>();
 
@@ -249,7 +245,7 @@ mod tests {
     #[test]
     fn test_forward_single_input_single_feature() {
         TestBackend::seed(0);
-        let config = LstmConfig::new(1, 1, false, 1);
+        let config = LstmConfig::new(1, 1, false);
         let mut lstm = config.init::<TestBackend>();
 
         fn create_gate_controller(


### PR DESCRIPTION
## Pull Request Template

### Checklist

- I've run all **std** checks and all tests pass except for 8 tests in record that require the static file path `/tmp/burn_test_file_recorder`, which is not valid on Windows.

### Related Issues/PRs

I haven't seen any related issues so I decided to do this pull request directly, since there are barely any changes.

### Changes

I have removed the `batch_size ` field from both GRU and LSTM, because they limit flexibility in exchange for nothing really.
This change increases compatibility with the Pytorch API (not necessary but nice).
If you run a RL workload and algorithm like PPO, during the rollout phase (data generation) you run with batch 1 but then during training phase you switch to whatever batch size you deem correct. Eliminating the field increases the flexibility for these kinds of situations and it doesn't impact saving and loading weights or performance (from what I have observed so far).

### Testing

I have ran the tests provided in the library and have not seen any performance differences for my workloads. May require further testing but the changes are very minor so I expect everything to work fine, once people adjust to the breaking changes.
