### PR TITLE
Fix formatting issues in the Burn Book's chapter 6: "Custom Training Loop"

### DIFF
--- a/burn-book/src/custom-training-loop.md
+++ b/burn-book/src/custom-training-loop.md
@@ -76,11 +76,8 @@ pub fn run<B: ADBackend>(device: B::Device) {
             let accuracy = accuracy(output, batch.targets);
 
             println!(
-                "[Train - Epoch {} - Iteration {}] Loss {:.3} | Accuracy {:.3} %",
-                iteration,
-                epoch,
+                "[Train - Epoch {epoch} - Iteration {iteration}] Loss {:.3} | Accuracy {accuracy:.3} %",
                 loss.clone().into_scalar(),
-                accuracy,
             );
 
             // Gradients for the current backward pass
@@ -101,11 +98,8 @@ pub fn run<B: ADBackend>(device: B::Device) {
             let accuracy = accuracy(output, batch.targets);
 
             println!(
-                "[Valid - Epoch {} - Iteration {}] Loss {} | Accuracy {}",
-                iteration,
-                epoch,
+                "[Valid - Epoch {epoch} - Iteration {iteration}] Loss {} | Accuracy {accuracy}",
                 loss.clone().into_scalar(),
-                accuracy,
             );
         }
     }


### PR DESCRIPTION
In some of the code in this chapter, I believe there is a mistake in formatting the output for the training and validation loops. The epoch counter and iteration counter were accidentally supplied to the wrong locations in the format string. I've fixed that and also made formatting a tad bit more idiomatic, by using the names of variables directly in the format string where possible.

*As I am still not an expert in this framework and AI terminology, it could be that this edit was mistaken, but I find that unlikely to be the case. If it is, I am sorry.*