### PR TITLE
tensor pretty print & summarize

### DIFF
--- a/burn-tensor/src/tests/stats/display.rs
+++ b/burn-tensor/src/tests/stats/display.rs
@@ -2,7 +2,7 @@
 mod tests {
     use super::*;
     use burn_tensor::backend::Backend;
-    use burn_tensor::{Data, Tensor};
+    use burn_tensor::{Data, Shape, Tensor};
 
     type FloatElem = <TestBackend as Backend>::FloatElem;
     type IntElem = <TestBackend as Backend>::IntElem;
@@ -15,8 +15,20 @@ mod tests {
 
         let output = format!("{}", tensor_int);
         let expected = format!(
-            "Tensor {{\n  data: [[1, 2, 3], [4, 5, 6], [7, 8, 9]],\n  shape:  [3, 3],\n  device:  {:?},\n  backend:  \"{}\",\n  kind:  \"Int\",\n  dtype:  \"{}\",\n}}",
-            tensor_int.device(), TestBackend::name(), core::any::type_name::<IntElem>()
+            r#"Tensor {{
+  data:
+[[1, 2, 3],
+ [4, 5, 6],
+ [7, 8, 9]],
+  shape:  [3, 3],
+  device:  {:?},
+  backend:  {:?},
+  kind:  "Int",
+  dtype:  "{dtype}",
+}}"#,
+            tensor_int.device(),
+            TestBackend::name(),
+            dtype = core::any::type_name::<IntElem>(),
         );
         assert_eq!(output, expected);
     }
@@ -29,8 +41,20 @@ mod tests {
 
         let output = format!("{}", tensor_float);
         let expected = format!(
-            "Tensor {{\n  data: [[1.1, 2.2, 3.3], [4.4, 5.5, 6.6], [7.7, 8.8, 9.9]],\n  shape:  [3, 3],\n  device:  {:?},\n  backend:  \"{}\",\n  kind:  \"Float\",\n  dtype:  \"{}\",\n}}",
-            tensor_float.device(), TestBackend::name(),  core::any::type_name::<FloatElem>()
+            r#"Tensor {{
+  data:
+[[1.1, 2.2, 3.3],
+ [4.4, 5.5, 6.6],
+ [7.7, 8.8, 9.9]],
+  shape:  [3, 3],
+  device:  {:?},
+  backend:  {:?},
+  kind:  "Float",
+  dtype:  "{dtype}",
+}}"#,
+            tensor_float.device(),
+            TestBackend::name(),
+            dtype = core::any::type_name::<FloatElem>(),
         );
         assert_eq!(output, expected);
     }
@@ -47,8 +71,19 @@ mod tests {
 
         let output = format!("{}", tensor_bool);
         let expected = format!(
-            "Tensor {{\n  data: [[true, false, true], [false, true, false], [false, true, true]],\n  shape:  [3, 3],\n  device:  {:?},\n  backend:  \"{}\",\n  kind:  \"Bool\",\n  dtype:  \"bool\",\n}}",
-            tensor_bool.device(), TestBackend::name()
+            r#"Tensor {{
+  data:
+[[true, false, true],
+ [false, true, false],
+ [false, true, true]],
+  shape:  [3, 3],
+  device:  {:?},
+  backend:  {:?},
+  kind:  "Bool",
+  dtype:  "bool",
+}}"#,
+            tensor_bool.device(),
+            TestBackend::name(),
         );
         assert_eq!(output, expected);
     }
@@ -63,11 +98,24 @@ mod tests {
 
         let output = format!("{}", tensor);
         let expected = format!(
-            "Tensor {{\n  data: [[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]], \
-                [[13, 14, 15, 16], [17, 18, 19, 20], [21, 22, 23, 24]]],\n  shape:  [2, 3, 4],\n  device:  {:?},\n  backend:  \"{}\",\n  kind:  \"Int\",\n  dtype:  \"{}\",\n}}",
-                tensor.device(), TestBackend::name(), core::any::type_name::<IntElem>()
-
-            );
+            r#"Tensor {{
+  data:
+[[[1, 2, 3, 4],
+  [5, 6, 7, 8],
+  [9, 10, 11, 12]],
+ [[13, 14, 15, 16],
+  [17, 18, 19, 20],
+  [21, 22, 23, 24]]],
+  shape:  [2, 3, 4],
+  device:  {:?},
+  backend:  {:?},
+  kind:  "Int",
+  dtype:  "{dtype}",
+}}"#,
+            tensor.device(),
+            TestBackend::name(),
+            dtype = core::any::type_name::<IntElem>(),
+        );
         assert_eq!(output, expected);
     }
 
@@ -82,8 +130,152 @@ mod tests {
 
         let output = format!("{}", tensor);
         let expected = format!(
-            "Tensor {{\n  data: [[[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]], [[[13, 14, 15], [16, 17, 18]], [[19, 20, 21], [22, 23, 24]]]],\n  shape:  [2, 2, 2, 3],\n  device:  {:?},\n  backend:  \"{}\",\n  kind:  \"Int\",\n  dtype:  \"{}\",\n}}",
-            tensor.device(), TestBackend::name(), core::any::type_name::<IntElem>()
+            r#"Tensor {{
+  data:
+[[[[1, 2, 3],
+   [4, 5, 6]],
+  [[7, 8, 9],
+   [10, 11, 12]]],
+ [[[13, 14, 15],
+   [16, 17, 18]],
+  [[19, 20, 21],
+   [22, 23, 24]]]],
+  shape:  [2, 2, 2, 3],
+  device:  {:?},
+  backend:  {:?},
+  kind:  "Int",
+  dtype:  "{dtype}",
+}}"#,
+            tensor.device(),
+            TestBackend::name(),
+            dtype = core::any::type_name::<IntElem>(),
+        );
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn test_display_tensor_summarize_1() {
+        let tensor: burn_tensor::Tensor<TestBackend, 4, burn_tensor::Float> =
+            Tensor::zeros(Shape::new([2, 2, 2, 1000]));
+
+        let output = format!("{}", tensor);
+        let expected = format!(
+            r#"Tensor {{
+  data:
+[[[[0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0]],
+  [[0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0]]],
+ [[[0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0]],
+  [[0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0]]]],
+  shape:  [2, 2, 2, 1000],
+  device:  {:?},
+  backend:  {:?},
+  kind:  "Float",
+  dtype:  "f32",
+}}"#,
+            tensor.device(),
+            TestBackend::name(),
+        );
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn test_display_tensor_summarize_2() {
+        let tensor: burn_tensor::Tensor<TestBackend, 4, burn_tensor::Float> =
+            Tensor::zeros(Shape::new([2, 2, 20, 100]));
+
+        let output = format!("{}", tensor);
+        let expected = format!(
+            r#"Tensor {{
+  data:
+[[[[0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0],
+   ...
+   [0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0]],
+  [[0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0],
+   ...
+   [0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0]]],
+ [[[0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0],
+   ...
+   [0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0]],
+  [[0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0],
+   ...
+   [0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0]]]],
+  shape:  [2, 2, 20, 100],
+  device:  {:?},
+  backend:  {:?},
+  kind:  "Float",
+  dtype:  "f32",
+}}"#,
+            tensor.device(),
+            TestBackend::name(),
+        );
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn test_display_tensor_summarize_3() {
+        let tensor: burn_tensor::Tensor<TestBackend, 4, burn_tensor::Float> =
+            Tensor::zeros(Shape::new([2, 2, 200, 6]));
+
+        let output = format!("{}", tensor);
+        let expected = format!(
+            r#"Tensor {{
+  data:
+[[[[0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+   ...
+   [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]],
+  [[0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+   ...
+   [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]],
+ [[[0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+   ...
+   [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]],
+  [[0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+   ...
+   [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+   [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]]],
+  shape:  [2, 2, 200, 6],
+  device:  {:?},
+  backend:  {:?},
+  kind:  "Float",
+  dtype:  "f32",
+}}"#,
+            tensor.device(),
+            TestBackend::name(),
         );
         assert_eq!(output, expected);
     }


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirm that `run-checks` script has been executed.

### Related Issues/PRs

https://github.com/burn-rs/burn/issues/850

### Changes

- I have refactored methods `display_recursive`, `fmt_inner_tensor`, `fmt_outer_tensor` and `push_newline_indent` to pretty print tensor and print ellipses (summarizing) when tensors get too large.
- Added `PrintOptions` to control how and when tensor will be pretty printed and summarized. 
- This implementation is similar to [candle's implementation](https://github.com/huggingface/candle/blob/4631c48273330753c25cf75616ade152915301a2/candle-core/src/display.rs#L3) for pretty print.
- Fixed old test cases to work with pretty print.

### Testing

- Added test cases to summarize large tensors.
