### PR TITLE
Also consider devices of type Other when trying to find the best device.

### DIFF
--- a/burn-wgpu/src/compute/base.rs
+++ b/burn-wgpu/src/compute/base.rs
@@ -195,22 +195,25 @@ fn select_adapter<G: GraphicsApi>(device: &WgpuDevice) -> wgpu::Adapter {
             let mut most_performant_adapter = None;
             let mut current_score = -1;
 
-            adapters.into_iter().for_each(|adapter| {
-                let info = adapter.get_info();
-                let score = match info.device_type {
-                    DeviceType::DiscreteGpu => 5,
-                    DeviceType::Other => 4, // Let's be optimistic with the Other device, it's
-                    // often a Discrete Gpu.
-                    DeviceType::IntegratedGpu => 3,
-                    DeviceType::VirtualGpu => 2,
-                    DeviceType::Cpu => 1,
-                };
+            adapters
+                .into_iter()
+                .chain(adapters_other)
+                .for_each(|adapter| {
+                    let info = adapter.get_info();
+                    let score = match info.device_type {
+                        DeviceType::DiscreteGpu => 5,
+                        DeviceType::Other => 4, // Let's be optimistic with the Other device, it's
+                        // often a Discrete Gpu.
+                        DeviceType::IntegratedGpu => 3,
+                        DeviceType::VirtualGpu => 2,
+                        DeviceType::Cpu => 1,
+                    };
 
-                if score > current_score {
-                    most_performant_adapter = Some(adapter);
-                    current_score = score;
-                }
-            });
+                    if score > current_score {
+                        most_performant_adapter = Some(adapter);
+                        current_score = score;
+                    }
+                });
 
             if let Some(adapter) = most_performant_adapter {
                 adapter


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirm that `run-checks` script has been executed.

`./run-checks.sh all`, if that makes any difference. It gets errors due to bad tolerances, but they're identical to those on `main`.

### Related Issues/PRs

Meant to fix issue reported in discord: https://discord.com/channels/1038839012602941528/1059209073784008835/1163541031086723162

### Changes

WgpuDevice::BestAvailable fails if there is a device of type Other available and nothing else, as it doesn't consider them.

### Testing

Not tested beyond `run-checks`. Would probably need some kind of mocking? Would like guidance on how to test this change.
