### PR TITLE
Add a `sync` feature to common, core, and tensor

### DIFF
--- a/burn-common/Cargo.toml
+++ b/burn-common/Cargo.toml
@@ -15,6 +15,7 @@ default = ["std"]
 
 std = ["rand/std"]
 
+sync = []
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 async-trait = { workspace = true }

--- a/burn-common/Cargo.toml
+++ b/burn-common/Cargo.toml
@@ -15,7 +15,7 @@ default = ["std"]
 
 std = ["rand/std"]
 
-sync = []
+wasm-sync = []
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 async-trait = { workspace = true }

--- a/burn-common/src/reader.rs
+++ b/burn-common/src/reader.rs
@@ -1,7 +1,7 @@
 use alloc::boxed::Box;
 use core::marker::PhantomData;
 
-#[cfg(target_family = "wasm")]
+#[cfg(all(not(feature = "sync"), target_family = "wasm"))]
 #[async_trait::async_trait]
 /// Allows to create async reader.
 pub trait AsyncReader<T>: Send {
@@ -15,10 +15,10 @@ pub enum Reader<T> {
     Concrete(T),
     /// Sync data variant.
     Sync(Box<dyn SyncReader<T>>),
-    #[cfg(target_family = "wasm")]
+    #[cfg(all(not(feature = "sync"), target_family = "wasm"))]
     /// Async data variant.
     Async(Box<dyn AsyncReader<T>>),
-    #[cfg(target_family = "wasm")]
+    #[cfg(all(not(feature = "sync"), target_family = "wasm"))]
     /// Future data variant.
     Future(core::pin::Pin<Box<dyn core::future::Future<Output = T> + Send>>),
 }
@@ -52,7 +52,7 @@ where
     }
 }
 
-#[cfg(target_family = "wasm")]
+#[cfg(all(not(feature = "sync"), target_family = "wasm"))]
 #[async_trait::async_trait]
 impl<I, O, F> AsyncReader<O> for MappedReader<I, O, F>
 where
@@ -67,7 +67,7 @@ where
 }
 
 impl<T> Reader<T> {
-    #[cfg(target_family = "wasm")]
+    #[cfg(all(not(feature = "sync"), target_family = "wasm"))]
     /// Read the data.
     pub async fn read(self) -> T {
         match self {
@@ -92,9 +92,9 @@ impl<T> Reader<T> {
         match self {
             Self::Concrete(data) => Some(data),
             Self::Sync(reader) => Some(reader.read()),
-            #[cfg(target_family = "wasm")]
+            #[cfg(all(not(feature = "sync"), target_family = "wasm"))]
             Self::Async(_func) => return None,
-            #[cfg(target_family = "wasm")]
+            #[cfg(all(not(feature = "sync"), target_family = "wasm"))]
             Self::Future(_future) => return None,
         }
     }
@@ -106,7 +106,7 @@ impl<T> Reader<T> {
         O: 'static + Send,
         F: 'static + Send,
     {
-        #[cfg(target_family = "wasm")]
+        #[cfg(all(not(feature = "sync"), target_family = "wasm"))]
         return Reader::Async(Box::new(MappedReader::new(self, mapper)));
 
         #[cfg(any(feature = "sync", not(target_family = "wasm")))]

--- a/burn-common/src/reader.rs
+++ b/burn-common/src/reader.rs
@@ -1,7 +1,7 @@
 use alloc::boxed::Box;
 use core::marker::PhantomData;
 
-#[cfg(all(not(feature = "sync"), target_family = "wasm"))]
+#[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
 #[async_trait::async_trait]
 /// Allows to create async reader.
 pub trait AsyncReader<T>: Send {
@@ -15,10 +15,10 @@ pub enum Reader<T> {
     Concrete(T),
     /// Sync data variant.
     Sync(Box<dyn SyncReader<T>>),
-    #[cfg(all(not(feature = "sync"), target_family = "wasm"))]
+    #[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
     /// Async data variant.
     Async(Box<dyn AsyncReader<T>>),
-    #[cfg(all(not(feature = "sync"), target_family = "wasm"))]
+    #[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
     /// Future data variant.
     Future(core::pin::Pin<Box<dyn core::future::Future<Output = T> + Send>>),
 }
@@ -52,7 +52,7 @@ where
     }
 }
 
-#[cfg(all(not(feature = "sync"), target_family = "wasm"))]
+#[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
 #[async_trait::async_trait]
 impl<I, O, F> AsyncReader<O> for MappedReader<I, O, F>
 where
@@ -67,7 +67,7 @@ where
 }
 
 impl<T> Reader<T> {
-    #[cfg(all(not(feature = "sync"), target_family = "wasm"))]
+    #[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
     /// Read the data.
     pub async fn read(self) -> T {
         match self {
@@ -78,7 +78,7 @@ impl<T> Reader<T> {
         }
     }
 
-    #[cfg(any(feature = "sync", not(target_family = "wasm")))]
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     /// Read the data.
     pub fn read(self) -> T {
         match self {
@@ -92,9 +92,9 @@ impl<T> Reader<T> {
         match self {
             Self::Concrete(data) => Some(data),
             Self::Sync(reader) => Some(reader.read()),
-            #[cfg(all(not(feature = "sync"), target_family = "wasm"))]
+            #[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
             Self::Async(_func) => return None,
-            #[cfg(all(not(feature = "sync"), target_family = "wasm"))]
+            #[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
             Self::Future(_future) => return None,
         }
     }
@@ -106,10 +106,10 @@ impl<T> Reader<T> {
         O: 'static + Send,
         F: 'static + Send,
     {
-        #[cfg(all(not(feature = "sync"), target_family = "wasm"))]
+        #[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
         return Reader::Async(Box::new(MappedReader::new(self, mapper)));
 
-        #[cfg(any(feature = "sync", not(target_family = "wasm")))]
+        #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
         Reader::Sync(Box::new(MappedReader::new(self, mapper)))
     }
 }

--- a/burn-common/src/reader.rs
+++ b/burn-common/src/reader.rs
@@ -78,7 +78,7 @@ impl<T> Reader<T> {
         }
     }
 
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(any(feature = "sync", not(target_family = "wasm")))]
     /// Read the data.
     pub fn read(self) -> T {
         match self {
@@ -109,7 +109,7 @@ impl<T> Reader<T> {
         #[cfg(target_family = "wasm")]
         return Reader::Async(Box::new(MappedReader::new(self, mapper)));
 
-        #[cfg(not(target_family = "wasm"))]
+        #[cfg(any(feature = "sync", not(target_family = "wasm")))]
         Reader::Sync(Box::new(MappedReader::new(self, mapper)))
     }
 }

--- a/burn-core/Cargo.toml
+++ b/burn-core/Cargo.toml
@@ -28,7 +28,8 @@ dataset = ["burn-dataset/default"]
 dataset-minimal = ["burn-dataset"]
 dataset-sqlite = ["burn-dataset/sqlite"]
 dataset-sqlite-bundled = ["burn-dataset/sqlite-bundled"]
-wasm-sync = []
+
+wasm-sync = ["burn-tensor/wasm-sync", "burn-common/wasm-sync"]
 
 # Backend
 autodiff = ["burn-autodiff"]

--- a/burn-core/Cargo.toml
+++ b/burn-core/Cargo.toml
@@ -28,7 +28,7 @@ dataset = ["burn-dataset/default"]
 dataset-minimal = ["burn-dataset"]
 dataset-sqlite = ["burn-dataset/sqlite"]
 dataset-sqlite-bundled = ["burn-dataset/sqlite-bundled"]
-sync = []
+wasm-sync = []
 
 # Backend
 autodiff = ["burn-autodiff"]

--- a/burn-core/Cargo.toml
+++ b/burn-core/Cargo.toml
@@ -28,6 +28,7 @@ dataset = ["burn-dataset/default"]
 dataset-minimal = ["burn-dataset"]
 dataset-sqlite = ["burn-dataset/sqlite"]
 dataset-sqlite-bundled = ["burn-dataset/sqlite-bundled"]
+sync = []
 
 # Backend
 autodiff = ["burn-autodiff"]

--- a/burn-core/src/grad_clipping/base.rs
+++ b/burn-core/src/grad_clipping/base.rs
@@ -68,7 +68,7 @@ impl GradientClipping {
         clipped_grad.mask_fill(lower_mask, -threshold)
     }
 
-    #[cfg(target_family = "wasm")]
+    #[cfg(all(not(feature = "sync"), target_family = "wasm"))]
     fn clip_by_norm<B: Backend, const D: usize>(
         &self,
         _grad: Tensor<B, D>,

--- a/burn-core/src/grad_clipping/base.rs
+++ b/burn-core/src/grad_clipping/base.rs
@@ -68,7 +68,7 @@ impl GradientClipping {
         clipped_grad.mask_fill(lower_mask, -threshold)
     }
 
-    #[cfg(all(not(feature = "sync"), target_family = "wasm"))]
+    #[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
     fn clip_by_norm<B: Backend, const D: usize>(
         &self,
         _grad: Tensor<B, D>,
@@ -77,7 +77,7 @@ impl GradientClipping {
         todo!("Not yet supported on wasm");
     }
 
-    #[cfg(any(feature = "sync", not(target_family = "wasm")))]
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     fn clip_by_norm<B: Backend, const D: usize>(
         &self,
         grad: Tensor<B, D>,
@@ -96,7 +96,7 @@ impl GradientClipping {
         }
     }
 
-    #[cfg(any(feature = "sync", not(target_family = "wasm")))]
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     fn l2_norm<B: Backend, const D: usize>(tensor: Tensor<B, D>) -> Tensor<B, 1> {
         let squared = tensor.powf(2.0);
         let sum = squared.sum();

--- a/burn-core/src/grad_clipping/base.rs
+++ b/burn-core/src/grad_clipping/base.rs
@@ -77,7 +77,7 @@ impl GradientClipping {
         todo!("Not yet supported on wasm");
     }
 
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(any(feature = "sync", not(target_family = "wasm")))]
     fn clip_by_norm<B: Backend, const D: usize>(
         &self,
         grad: Tensor<B, D>,
@@ -96,7 +96,7 @@ impl GradientClipping {
         }
     }
 
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(any(feature = "sync", not(target_family = "wasm")))]
     fn l2_norm<B: Backend, const D: usize>(tensor: Tensor<B, D>) -> Tensor<B, 1> {
         let squared = tensor.powf(2.0);
         let sum = squared.sum();

--- a/burn-core/src/record/tensor.rs
+++ b/burn-core/src/record/tensor.rs
@@ -89,10 +89,10 @@ impl<B: Backend, const D: usize> Record for Tensor<B, D> {
     type Item<S: PrecisionSettings> = FloatTensorSerde<S>;
 
     fn into_item<S: PrecisionSettings>(self) -> Self::Item<S> {
-        #[cfg(all(not(feature = "sync"), target_family = "wasm"))]
+        #[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
         todo!("Recording float tensors isn't yet supported on wasm.");
 
-        #[cfg(any(feature = "sync", not(target_family = "wasm")))]
+        #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
         FloatTensorSerde::new(self.into_data().convert().serialize())
     }
 
@@ -105,10 +105,10 @@ impl<B: Backend, const D: usize> Record for Tensor<B, D, Int> {
     type Item<S: PrecisionSettings> = IntTensorSerde<S>;
 
     fn into_item<S: PrecisionSettings>(self) -> Self::Item<S> {
-        #[cfg(all(not(feature = "sync"), target_family = "wasm"))]
+        #[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
         todo!("Recording int tensors isn't yet supported on wasm.");
 
-        #[cfg(any(feature = "sync", not(target_family = "wasm")))]
+        #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
         IntTensorSerde::new(self.into_data().convert().serialize())
     }
 
@@ -121,10 +121,10 @@ impl<B: Backend, const D: usize> Record for Tensor<B, D, Bool> {
     type Item<S: PrecisionSettings> = BoolTensorSerde;
 
     fn into_item<S: PrecisionSettings>(self) -> Self::Item<S> {
-        #[cfg(all(not(feature = "sync"), target_family = "wasm"))]
+        #[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
         todo!("Recording bool tensors isn't yet supported on wasm.");
 
-        #[cfg(any(feature = "sync", not(target_family = "wasm")))]
+        #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
         BoolTensorSerde::new(self.into_data().serialize())
     }
 

--- a/burn-core/src/record/tensor.rs
+++ b/burn-core/src/record/tensor.rs
@@ -92,7 +92,7 @@ impl<B: Backend, const D: usize> Record for Tensor<B, D> {
         #[cfg(target_family = "wasm")]
         todo!("Recording float tensors isn't yet supported on wasm.");
 
-        #[cfg(not(target_family = "wasm"))]
+        #[cfg(any(feature = "sync", not(target_family = "wasm")))]
         FloatTensorSerde::new(self.into_data().convert().serialize())
     }
 
@@ -108,7 +108,7 @@ impl<B: Backend, const D: usize> Record for Tensor<B, D, Int> {
         #[cfg(target_family = "wasm")]
         todo!("Recording int tensors isn't yet supported on wasm.");
 
-        #[cfg(not(target_family = "wasm"))]
+        #[cfg(any(feature = "sync", not(target_family = "wasm")))]
         IntTensorSerde::new(self.into_data().convert().serialize())
     }
 
@@ -124,7 +124,7 @@ impl<B: Backend, const D: usize> Record for Tensor<B, D, Bool> {
         #[cfg(target_family = "wasm")]
         todo!("Recording bool tensors isn't yet supported on wasm.");
 
-        #[cfg(not(target_family = "wasm"))]
+        #[cfg(any(feature = "sync", not(target_family = "wasm")))]
         BoolTensorSerde::new(self.into_data().serialize())
     }
 

--- a/burn-core/src/record/tensor.rs
+++ b/burn-core/src/record/tensor.rs
@@ -89,7 +89,7 @@ impl<B: Backend, const D: usize> Record for Tensor<B, D> {
     type Item<S: PrecisionSettings> = FloatTensorSerde<S>;
 
     fn into_item<S: PrecisionSettings>(self) -> Self::Item<S> {
-        #[cfg(target_family = "wasm")]
+        #[cfg(all(not(feature = "sync"), target_family = "wasm"))]
         todo!("Recording float tensors isn't yet supported on wasm.");
 
         #[cfg(any(feature = "sync", not(target_family = "wasm")))]
@@ -105,7 +105,7 @@ impl<B: Backend, const D: usize> Record for Tensor<B, D, Int> {
     type Item<S: PrecisionSettings> = IntTensorSerde<S>;
 
     fn into_item<S: PrecisionSettings>(self) -> Self::Item<S> {
-        #[cfg(target_family = "wasm")]
+        #[cfg(all(not(feature = "sync"), target_family = "wasm"))]
         todo!("Recording int tensors isn't yet supported on wasm.");
 
         #[cfg(any(feature = "sync", not(target_family = "wasm")))]
@@ -121,7 +121,7 @@ impl<B: Backend, const D: usize> Record for Tensor<B, D, Bool> {
     type Item<S: PrecisionSettings> = BoolTensorSerde;
 
     fn into_item<S: PrecisionSettings>(self) -> Self::Item<S> {
-        #[cfg(target_family = "wasm")]
+        #[cfg(all(not(feature = "sync"), target_family = "wasm"))]
         todo!("Recording bool tensors isn't yet supported on wasm.");
 
         #[cfg(any(feature = "sync", not(target_family = "wasm")))]

--- a/burn-core/src/record/tensor.rs
+++ b/burn-core/src/record/tensor.rs
@@ -44,7 +44,6 @@ impl<'de, S: PrecisionSettings> Deserialize<'de> for FloatTensorSerde<S> {
     }
 }
 
-// #[cfg(not(target_family = "wasm"))]
 impl<S: PrecisionSettings> Serialize for IntTensorSerde<S> {
     fn serialize<Se>(&self, serializer: Se) -> Result<Se::Ok, Se::Error>
     where

--- a/burn-tensor/Cargo.toml
+++ b/burn-tensor/Cargo.toml
@@ -16,6 +16,7 @@ experimental-named-tensor = []
 export_tests = ["burn-tensor-testgen"]
 std = ["rand/std", "half/std"]
 benchmark = []
+sync = []
 
 [dependencies]
 burn-common = { path = "../burn-common", version = "0.10.0", default-features = false }

--- a/burn-tensor/Cargo.toml
+++ b/burn-tensor/Cargo.toml
@@ -16,7 +16,7 @@ experimental-named-tensor = []
 export_tests = ["burn-tensor-testgen"]
 std = ["rand/std", "half/std"]
 benchmark = []
-sync = []
+wasm-sync = []
 
 [dependencies]
 burn-common = { path = "../burn-common", version = "0.10.0", default-features = false }

--- a/burn-tensor/src/tensor/api/base.rs
+++ b/burn-tensor/src/tensor/api/base.rs
@@ -2,11 +2,11 @@
 
 use alloc::vec::Vec;
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(any(feature = "sync", not(target_family = "wasm")))]
 use alloc::format;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(any(feature = "sync", not(target_family = "wasm")))]
 use alloc::string::String;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(any(feature = "sync", not(target_family = "wasm")))]
 use alloc::vec;
 
 use burn_common::{reader::Reader, stub::Mutex};
@@ -331,7 +331,7 @@ where
         K::into_data(self.primitive).read().await
     }
 
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(any(feature = "sync", not(target_family = "wasm")))]
     /// Returns the data of the current tensor.
     pub fn into_data(self) -> Data<K::Elem, D> {
         K::into_data(self.primitive).read()
@@ -343,7 +343,7 @@ where
         K::into_data(self.primitive.clone()).read().await
     }
 
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(any(feature = "sync", not(target_family = "wasm")))]
     /// Returns the data of the current tensor without taking ownership.
     pub fn to_data(&self) -> Data<K::Elem, D> {
         Self::into_data(self.clone())
@@ -467,7 +467,7 @@ where
     K: BasicOps<B>,
     <K as BasicOps<B>>::Elem: Debug,
 {
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(any(feature = "sync", not(target_family = "wasm")))]
     #[inline]
     fn push_newline_indent(acc: &mut String, indent: usize) {
         acc.push('\n');
@@ -476,7 +476,7 @@ where
         }
     }
 
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(any(feature = "sync", not(target_family = "wasm")))]
     fn fmt_inner_tensor(
         &self,
         acc: &mut String,
@@ -498,7 +498,7 @@ where
         }
     }
 
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(any(feature = "sync", not(target_family = "wasm")))]
     fn fmt_outer_tensor(
         &self,
         acc: &mut String,
@@ -533,7 +533,7 @@ where
     /// * `acc` - A mutable reference to a `String` used as an accumulator for the formatted output.
     /// * `depth` - The current depth of the tensor dimensions being processed.
     /// * `multi_index` - A mutable slice of `usize` representing the current indices in each dimension.
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(any(feature = "sync", not(target_family = "wasm")))]
     fn display_recursive(
         &self,
         acc: &mut String,
@@ -644,7 +644,7 @@ where
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         writeln!(f, "Tensor {{")?;
 
-        #[cfg(not(target_family = "wasm"))]
+        #[cfg(any(feature = "sync", not(target_family = "wasm")))]
         {
             let po = PRINT_OPTS.lock().unwrap();
             let mut acc = String::new();

--- a/burn-tensor/src/tensor/api/base.rs
+++ b/burn-tensor/src/tensor/api/base.rs
@@ -325,7 +325,7 @@ where
         Self::new(K::to_device(self.primitive, device))
     }
 
-    #[cfg(target_family = "wasm")]
+    #[cfg(all(not(feature = "sync"), target_family = "wasm"))]
     /// Returns the data of the current tensor.
     pub async fn into_data(self) -> Data<K::Elem, D> {
         K::into_data(self.primitive).read().await
@@ -337,7 +337,7 @@ where
         K::into_data(self.primitive).read()
     }
 
-    #[cfg(target_family = "wasm")]
+    #[cfg(all(not(feature = "sync"), target_family = "wasm"))]
     /// Returns the data of the current tensor.
     pub async fn to_data(&self) -> Data<K::Elem, D> {
         K::into_data(self.primitive.clone()).read().await

--- a/burn-tensor/src/tensor/api/base.rs
+++ b/burn-tensor/src/tensor/api/base.rs
@@ -2,11 +2,11 @@
 
 use alloc::vec::Vec;
 
-#[cfg(any(feature = "sync", not(target_family = "wasm")))]
+#[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
 use alloc::format;
-#[cfg(any(feature = "sync", not(target_family = "wasm")))]
+#[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
 use alloc::string::String;
-#[cfg(any(feature = "sync", not(target_family = "wasm")))]
+#[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
 use alloc::vec;
 
 use burn_common::{reader::Reader, stub::Mutex};
@@ -325,25 +325,25 @@ where
         Self::new(K::to_device(self.primitive, device))
     }
 
-    #[cfg(all(not(feature = "sync"), target_family = "wasm"))]
+    #[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
     /// Returns the data of the current tensor.
     pub async fn into_data(self) -> Data<K::Elem, D> {
         K::into_data(self.primitive).read().await
     }
 
-    #[cfg(any(feature = "sync", not(target_family = "wasm")))]
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     /// Returns the data of the current tensor.
     pub fn into_data(self) -> Data<K::Elem, D> {
         K::into_data(self.primitive).read()
     }
 
-    #[cfg(all(not(feature = "sync"), target_family = "wasm"))]
+    #[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
     /// Returns the data of the current tensor.
     pub async fn to_data(&self) -> Data<K::Elem, D> {
         K::into_data(self.primitive.clone()).read().await
     }
 
-    #[cfg(any(feature = "sync", not(target_family = "wasm")))]
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     /// Returns the data of the current tensor without taking ownership.
     pub fn to_data(&self) -> Data<K::Elem, D> {
         Self::into_data(self.clone())
@@ -467,7 +467,7 @@ where
     K: BasicOps<B>,
     <K as BasicOps<B>>::Elem: Debug,
 {
-    #[cfg(any(feature = "sync", not(target_family = "wasm")))]
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     #[inline]
     fn push_newline_indent(acc: &mut String, indent: usize) {
         acc.push('\n');
@@ -476,7 +476,7 @@ where
         }
     }
 
-    #[cfg(any(feature = "sync", not(target_family = "wasm")))]
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     fn fmt_inner_tensor(
         &self,
         acc: &mut String,
@@ -498,7 +498,7 @@ where
         }
     }
 
-    #[cfg(any(feature = "sync", not(target_family = "wasm")))]
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     fn fmt_outer_tensor(
         &self,
         acc: &mut String,
@@ -533,7 +533,7 @@ where
     /// * `acc` - A mutable reference to a `String` used as an accumulator for the formatted output.
     /// * `depth` - The current depth of the tensor dimensions being processed.
     /// * `multi_index` - A mutable slice of `usize` representing the current indices in each dimension.
-    #[cfg(any(feature = "sync", not(target_family = "wasm")))]
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     fn display_recursive(
         &self,
         acc: &mut String,
@@ -644,7 +644,7 @@ where
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         writeln!(f, "Tensor {{")?;
 
-        #[cfg(any(feature = "sync", not(target_family = "wasm")))]
+        #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
         {
             let po = PRINT_OPTS.lock().unwrap();
             let mut acc = String::new();

--- a/burn-tensor/src/tensor/api/numeric.rs
+++ b/burn-tensor/src/tensor/api/numeric.rs
@@ -9,7 +9,7 @@ where
     K: Numeric<B>,
     K::Elem: Element,
 {
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(any(feature = "sync", not(target_family = "wasm")))]
     /// Convert the tensor into a scalar.
     ///
     /// # Panics

--- a/burn-tensor/src/tensor/api/numeric.rs
+++ b/burn-tensor/src/tensor/api/numeric.rs
@@ -21,7 +21,7 @@ where
         data.value[0]
     }
 
-    #[cfg(target_family = "wasm")]
+    #[cfg(all(not(feature = "sync"), target_family = "wasm"))]
     /// Convert the tensor into a scalar.
     ///
     /// # Panics

--- a/burn-tensor/src/tensor/api/numeric.rs
+++ b/burn-tensor/src/tensor/api/numeric.rs
@@ -9,7 +9,7 @@ where
     K: Numeric<B>,
     K::Elem: Element,
 {
-    #[cfg(any(feature = "sync", not(target_family = "wasm")))]
+    #[cfg(any(feature = "wasm-sync", not(target_family = "wasm")))]
     /// Convert the tensor into a scalar.
     ///
     /// # Panics
@@ -21,7 +21,7 @@ where
         data.value[0]
     }
 
-    #[cfg(all(not(feature = "sync"), target_family = "wasm"))]
+    #[cfg(all(not(feature = "wasm-sync"), target_family = "wasm"))]
     /// Convert the tensor into a scalar.
     ///
     /// # Panics

--- a/burn/Cargo.toml
+++ b/burn/Cargo.toml
@@ -19,7 +19,7 @@ std = ["burn-core/std"]
 train = ["burn-train/default", "autodiff", "dataset"]
 
 # Useful when targeting WASM and not using WGPU.
-wasm-sync = ["burn-tensor/wasm-sync", "burn-core/wasm-sync", "burn-common/wasm-sync"]
+wasm-sync = ["burn-core/wasm-sync"]
 
 ## Include nothing
 train-minimal = ["burn-train"]
@@ -60,8 +60,6 @@ experimental-named-tensor = ["burn-core/experimental-named-tensor"]
 
 burn-core = { path = "../burn-core", version = "0.10.0", default-features = false }
 burn-train = { path = "../burn-train", version = "0.10.0", optional = true, default-features = false }
-burn-common = { path = "../burn-common", version = "0.10.0", optional = true, default-features = false }
-burn-tensor = { path = "../burn-tensor", version = "0.10.0", optional = true, default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/burn/Cargo.toml
+++ b/burn/Cargo.toml
@@ -18,8 +18,8 @@ std = ["burn-core/std"]
 # Training with full features
 train = ["burn-train/default", "autodiff", "dataset"]
 
-# Use synchronous APIs. Useful when targeting WASM and not using WGPU.
-sync = ["burn-tensor/sync", "burn-core/sync", "burn-common/sync"]
+# Useful when targeting WASM and not using WGPU.
+wasm-sync = ["burn-tensor/wasm-sync", "burn-core/wasm-sync", "burn-common/wasm-sync"]
 
 ## Include nothing
 train-minimal = ["burn-train"]

--- a/burn/Cargo.toml
+++ b/burn/Cargo.toml
@@ -18,6 +18,9 @@ std = ["burn-core/std"]
 # Training with full features
 train = ["burn-train/default", "autodiff", "dataset"]
 
+# Use synchronous APIs. Useful when targeting WASM and not using WGPU.
+sync = ["burn-tensor/sync", "burn-core/sync", "burn-common/sync"]
+
 ## Include nothing
 train-minimal = ["burn-train"]
 
@@ -57,6 +60,8 @@ experimental-named-tensor = ["burn-core/experimental-named-tensor"]
 
 burn-core = { path = "../burn-core", version = "0.10.0", default-features = false }
 burn-train = { path = "../burn-train", version = "0.10.0", optional = true, default-features = false }
+burn-common = { path = "../burn-common", version = "0.10.0", optional = true, default-features = false }
+burn-tensor = { path = "../burn-tensor", version = "0.10.0", optional = true, default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/examples/mnist-inference-web/build-for-web.sh
+++ b/examples/mnist-inference-web/build-for-web.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 
 # Add wasm32 target for compiler.
 rustup target add wasm32-unknown-unknown

--- a/examples/mnist-inference-web/run-server.sh
+++ b/examples/mnist-inference-web/run-server.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 
 # Opening index.html file directly by a browser does not work because of
 # the security restrictions by the browser. Viewing the HTML file will fail with 


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [?] Confirm that `run-checks` script has been executed.

Failed with the same error [as last time](https://github.com/burn-rs/burn/pull/830), more or less.

### Related Issues/PRs

Resolves https://github.com/burn-rs/burn/issues/865.

Continuing the discussion from the above issue: After a truly embarrassing amount of spinning in circles, I don't think I can get Asyncify to work with wgpu. WGPU is, at its foundation, async, [and critical apis don't have a synchronous version](https://github.com/gfx-rs/wgpu/issues/3509). Asyncify only works on wasm files. WGPU is async _Rust_, so asyncify can't "de-async" it for our consumption.

### Changes

So instead I pull the same trick as last time and feature flag stuff. I add a `sync` feature that I can use to get sync behavior when targeting WASM.

### Testing

Add

```
burn = {path = "../../burn", default-features = false, features = ["train-minimal", "ndarray-no-std", "sync"]}
getrandom = { version = "0.2", features = ["js"] }
```

to https://github.com/burn-rs/burn/blob/main/examples/mnist-inference-web/Cargo.toml, delete [this await](https://github.com/burn-rs/burn/blob/38e88a79bda0f5654b100e712539e7a8081ac3f5/examples/mnist-inference-web/src/web.rs#L68), and observe that ` ./build-for-web.sh ndarray` builds.