### PR TITLE
Use const seed

### DIFF
--- a/burn-common/Cargo.toml
+++ b/burn-common/Cargo.toml
@@ -23,7 +23,6 @@ getrandom = { workspace = true, features = ["js"] }
 [dependencies]
 # ** Please make sure all dependencies support no_std when std is disabled **
 
-const-random = { workspace = true }
 rand = { workspace = true }
 spin = { workspace = true }         # using in place of use std::sync::Mutex;          
 uuid = { workspace = true }

--- a/burn-common/src/rand.rs
+++ b/burn-common/src/rand.rs
@@ -1,7 +1,5 @@
 pub use rand::{rngs::StdRng, Rng, SeedableRng};
 
-#[cfg(not(feature = "std"))]
-use const_random::const_random;
 use rand::distributions::Standard;
 use rand::prelude::Distribution;
 
@@ -16,8 +14,8 @@ pub fn get_seeded_rng() -> StdRng {
 #[cfg(not(feature = "std"))]
 #[inline(always)]
 pub fn get_seeded_rng() -> StdRng {
-    const GENERATED_SEED: u64 = const_random!(u64);
-    StdRng::seed_from_u64(GENERATED_SEED)
+    const CONST_SEED: u64 = 42;
+    StdRng::seed_from_u64(CONST_SEED)
 }
 
 /// Generates random data from a thread-local RNG.


### PR DESCRIPTION
Fixes the CI.

Currently, the generated seed is the same when the binary executes, but changes each time the program is compiled. This doesn't add any statistical properties and can make different builds have different behavior, so I don't see any problem using a static seed in this case.