### PR TITLE
Fixing Docs.rs

### DIFF
--- a/burn/Cargo.toml
+++ b/burn/Cargo.toml
@@ -62,4 +62,4 @@ burn-core = { path = "../burn-core", version = "0.11.0", default-features = fals
 burn-train = { path = "../burn-train", version = "0.11.0", optional = true, default-features = false }
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["dataset", "default", "std", "train", "train-tui", "train-metrics", "dataset-sqlite"]


### PR DESCRIPTION
At the moment docs.rs fails to compile due to
not being able to link to Cuda or other backend
specific configurations, which it seemingly has
to do to compile the docs of those crates.

I have now removed the backends from being part
of the included features to be displayed on
docs.rs, so that only the crates that pertains
to the upper-level api remains.

As it was me who added the all-features flag in
the first place, I must apologize for any
inconvenience caused!

The resulting docs.rs output can be seen by running: cargo doc -F dataset -F default -F std -F train -F train-tui -F train-metrics -F dataset-sqlite --open
