### PR TITLE
CI/Remove_codecov_annotations

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,3 +7,5 @@ coverage:
     patch:
       default:
         target: 80%
+github_checks:
+    annotations: false


### PR DESCRIPTION
Suggesting to remove the codecov annotations, see bottom right in this image. They're really annoying me when reviewing!

![image](https://github.com/burn-rs/burn/assets/12396024/7981f6bd-de7f-4261-a7dd-9b1eef5f02bb)
