### PR TITLE
Pin candle-core version to "0.3.0" version

### DIFF
--- a/burn-candle/Cargo.toml
+++ b/burn-candle/Cargo.toml
@@ -17,7 +17,9 @@ cuda = ["candle-core/cuda"]
 derive-new = { workspace = true }
 burn-tensor = { path = "../burn-tensor", version = "0.11.0", default-features = false }
 half = { workspace = true }
-candle-core = { version = "0.3.0" }
+
+# TODO remove pinned version ("=") once candle-core is updated to 0.3.1
+candle-core = { version = "=0.3.0" }
 
 [dev-dependencies]
 burn-autodiff = { path = "../burn-autodiff", version = "0.11.0", default-features = false, features = [


### PR DESCRIPTION
## Pull Request Template

### Changes

Candle core 0.3.1 release contains a breaking changes so this is a workaround to pin to "0.3.0".

### Testing

Ran build